### PR TITLE
Added commitment parameters to GetBalance, GetAccountInfo and GetBloc…

### DIFF
--- a/src/Solnet.Rpc/IRpcClient.cs
+++ b/src/Solnet.Rpc/IRpcClient.cs
@@ -20,17 +20,25 @@ namespace Solnet.Rpc
 
         /// <summary>
         /// Gets the account info using base64 encoding. This is an asynchronous operation.
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
         /// </summary>
         /// <param name="pubKey">The account public key.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>A task which may return a request result holding the context and account info.</returns>
-        Task<RequestResult<ResponseValue<AccountInfo>>> GetAccountInfoAsync(string pubKey);
+        Task<RequestResult<ResponseValue<AccountInfo>>> GetAccountInfoAsync(string pubKey, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Gets the account info using base64 encoding. This is a synchronous operation.
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
         /// </summary>
         /// <param name="pubKey">The account public key.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<AccountInfo>> GetAccountInfo(string pubKey);
+        RequestResult<ResponseValue<AccountInfo>> GetAccountInfo(string pubKey, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Returns all accounts owned by the provided program Pubkey. This is an asynchronous operation.
@@ -61,28 +69,48 @@ namespace Solnet.Rpc
         RequestResult<ResponseValue<List<AccountInfo>>> GetMultipleAccounts(IList<string> accounts);
 
         /// <summary>
-        /// Gets the balance for a certain public key.
+        /// Gets the balance <b>asynchronously</b> for a certain public key.
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
         /// </summary>
         /// <param name="pubKey">The public key.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>A task which may return a request result holding the context and address balance.</returns>
-        Task<RequestResult<ResponseValue<ulong>>> GetBalanceAsync(string pubKey);
+        Task<RequestResult<ResponseValue<ulong>>> GetBalanceAsync(string pubKey, Commitment commitment = Commitment.Finalized);
 
-        /// <inheritdoc cref="SolanaRpcClient.GetBalanceAsync"/>
-        RequestResult<ResponseValue<ulong>> GetBalance(string pubKey);
+        /// <summary>
+        /// Gets the balance <b>synchronously</b> for a certain public key.
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
+        /// </summary>
+        /// <param name="pubKey">The public key.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
+        RequestResult<ResponseValue<ulong>> GetBalance(string pubKey, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Returns identity and transaction information about a confirmed block in the ledger. This is an asynchronous operation.
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
         /// </summary>
         /// <param name="slot">The slot.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
-        Task<RequestResult<BlockInfo>> GetBlockAsync(ulong slot);
+        Task<RequestResult<BlockInfo>> GetBlockAsync(ulong slot, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Returns identity and transaction information about a confirmed block in the ledger. This is a synchronous operation.
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
         /// </summary>
         /// <param name="slot">The slot.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<BlockInfo> GetBlock(ulong slot);
+        RequestResult<BlockInfo> GetBlock(ulong slot, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Returns recent block production information from the current or previous epoch. This is an asynchronous operation.

--- a/src/Solnet.Rpc/SolanaRpcClient.cs
+++ b/src/Solnet.Rpc/SolanaRpcClient.cs
@@ -109,23 +109,23 @@ namespace Solnet.Rpc
         #endregion
 
         #region Accounts
-        /// <inheritdoc cref="IRpcClient.GetAccountInfoAsync(string)"/>
-        public async Task<RequestResult<ResponseValue<AccountInfo>>> GetAccountInfoAsync(string pubKey)
+        /// <inheritdoc cref="IRpcClient.GetAccountInfoAsync(string,Commitment)"/>
+        public async Task<RequestResult<ResponseValue<AccountInfo>>> GetAccountInfoAsync(string pubKey, Commitment commitment = Commitment.Finalized)
         {
-            return await SendRequestAsync<ResponseValue<AccountInfo>>(
-                "getAccountInfo",
-                new List<object> { pubKey },
-                new Dictionary<string, object>
-                {
-                    {
-                        "encoding", "base64"
-                    }
-                });
+            var configParams = new Dictionary<string, object> { { "encoding", "base64" } };
+
+            // given that finalized is the default, lets not add it to speed things up
+            if (commitment != Commitment.Finalized)
+            {
+                configParams.Add("commitment", commitment);
+            }
+
+            return await SendRequestAsync<ResponseValue<AccountInfo>>("getAccountInfo", new List<object> { pubKey, configParams });
         }
 
-        /// <inheritdoc cref="IRpcClient.GetAccountInfo(string)"/>
-        public RequestResult<ResponseValue<AccountInfo>> GetAccountInfo(string pubKey)
-            => GetAccountInfoAsync(pubKey).Result;
+        /// <inheritdoc cref="IRpcClient.GetAccountInfo(string,Commitment)"/>
+        public RequestResult<ResponseValue<AccountInfo>> GetAccountInfo(string pubKey, Commitment commitment = Commitment.Finalized)
+            => GetAccountInfoAsync(pubKey, commitment).Result;
 
 
         /// <inheritdoc cref="IRpcClient.GetProgramAccountsAsync(string)"/>
@@ -159,30 +159,40 @@ namespace Solnet.Rpc
 
         #endregion
 
-        /// <summary>
-        /// Gets the balance for a certain public key.
-        /// </summary>
-        /// <param name="pubKey">The public key.</param>
-        /// <returns>A task which may return a request result holding the context and address balance.</returns>
-        public async Task<RequestResult<ResponseValue<ulong>>> GetBalanceAsync(string pubKey)
+        /// <inheritdoc cref="IRpcClient.GetBalanceAsync"/>
+        public async Task<RequestResult<ResponseValue<ulong>>> GetBalanceAsync(string pubKey, Commitment commitment = Commitment.Finalized)
         {
-            return await SendRequestAsync<ResponseValue<ulong>>("getBalance", new List<object> { pubKey });
+            var paramsList = new List<object> { pubKey };
+
+            if (commitment != Commitment.Finalized)
+            {
+                paramsList.Add(new Dictionary<string, Commitment> { { "commitment", commitment } });
+            }
+
+            return await SendRequestAsync<ResponseValue<ulong>>("getBalance", paramsList);
         }
 
-        /// <inheritdoc cref="GetBalanceAsync"/>
-        public RequestResult<ResponseValue<ulong>> GetBalance(string pubKey)
-            => GetBalanceAsync(pubKey).Result;
+        /// <inheritdoc cref="IRpcClient.GetBalance"/>
+        public RequestResult<ResponseValue<ulong>> GetBalance(string pubKey, Commitment commitment = Commitment.Finalized)
+            => GetBalanceAsync(pubKey, commitment).Result;
 
         #region Blocks
-        /// <inheritdoc cref="IRpcClient.GetBlockAsync(ulong)"/>
-        public async Task<RequestResult<BlockInfo>> GetBlockAsync(ulong slot)
+        /// <inheritdoc cref="IRpcClient.GetBlockAsync(ulong,Commitment)"/>
+        public async Task<RequestResult<BlockInfo>> GetBlockAsync(ulong slot, Commitment commitment = Commitment.Finalized)
         {
-            return await SendRequestAsync<BlockInfo>("getBlock",
-                new List<object> { slot, new Dictionary<string, string> { { "encoding", "json" }, { "transactionDetails", "full" } } });
+            // transaction details default is aready full
+            var configParams = new Dictionary<string, object> { { "encoding", "json" } };
+
+            if (commitment != Commitment.Finalized)
+            {
+                configParams.Add("commitment", commitment);
+            }
+
+            return await SendRequestAsync<BlockInfo>("getBlock", new List<object> { slot, configParams });
         }
 
-        /// <inheritdoc cref="IRpcClient.GetBlock(ulong)"/>
-        public RequestResult<BlockInfo> GetBlock(ulong slot)
+        /// <inheritdoc cref="IRpcClient.GetBlock(ulong,Commitment)"/>
+        public RequestResult<BlockInfo> GetBlock(ulong slot, Commitment commitment = Commitment.Finalized)
             => GetBlockAsync(slot).Result;
 
 

--- a/test/Solnet.Rpc.Test/Resources/Http/Accounts/GetAccountInfoConfirmedRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Accounts/GetAccountInfoConfirmedRequest.json
@@ -1,0 +1,1 @@
+{"method":"getAccountInfo","params":["9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5",{"encoding":"base64","commitment":"confirmed"}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/Blocks/GetBlockConfirmedRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Blocks/GetBlockConfirmedRequest.json
@@ -1,0 +1,1 @@
+{"method":"getBlock","params":[79662905,{"encoding":"json","commitment":"confirmed"}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/Blocks/GetBlockRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Blocks/GetBlockRequest.json
@@ -1,1 +1,1 @@
-{"method":"getBlock","params":[79662905,{"encoding":"json","transactionDetails":"full"}],"jsonrpc":"2.0","id":0}
+{"method":"getBlock","params":[79662905,{"encoding":"json"}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/GetBalanceConfirmedRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/GetBalanceConfirmedRequest.json
@@ -1,0 +1,1 @@
+{"method":"getBalance","params":["hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh",{"commitment":"confirmed"}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/SolanaRpcClientAccountTests.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientAccountTests.cs
@@ -1,0 +1,152 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Solnet.Rpc.Test
+{
+    public partial class SolanaRpcClientTest
+    {
+        [TestMethod]
+        public void TestGetAccountInfoDefault()
+        {
+            var responseData = File.ReadAllText("Resources/Http/Accounts/GetAccountInfoResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Accounts/GetAccountInfoRequest.json");
+
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var result = sut.GetAccountInfo("9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(79200467UL, result.Result.Context.Slot);
+            Assert.AreEqual("", result.Result.Value.Data[0]);
+            Assert.AreEqual("base64", result.Result.Value.Data[1]);
+            Assert.AreEqual(false, result.Result.Value.Executable);
+            Assert.AreEqual(5478840UL, result.Result.Value.Lamports);
+            Assert.AreEqual("11111111111111111111111111111111", result.Result.Value.Owner);
+            Assert.AreEqual(195UL, result.Result.Value.RentEpoch);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetAccountInfoConfirmed()
+        {
+            var responseData = File.ReadAllText("Resources/Http/Accounts/GetAccountInfoResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Accounts/GetAccountInfoConfirmedRequest.json");
+
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var result = sut.GetAccountInfo("9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5", Types.Commitment.Confirmed);
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(79200467UL, result.Result.Context.Slot);
+            Assert.AreEqual("", result.Result.Value.Data[0]);
+            Assert.AreEqual("base64", result.Result.Value.Data[1]);
+            Assert.AreEqual(false, result.Result.Value.Executable);
+            Assert.AreEqual(5478840UL, result.Result.Value.Lamports);
+            Assert.AreEqual("11111111111111111111111111111111", result.Result.Value.Owner);
+            Assert.AreEqual(195UL, result.Result.Value.RentEpoch);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+
+        [TestMethod]
+        public void TestGetProgramAccounts()
+        {
+            var responseData = File.ReadAllText("Resources/Http/Accounts/GetProgramAccountsResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Accounts/GetProgramAccountsRequest.json");
+
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var result = sut.GetProgramAccounts("GrAkKfEpTKQuVHG2Y97Y2FF4i7y7Q5AHLK94JBy7Y5yv");
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(2, result.Result.Count);
+            Assert.AreEqual("FzNKvS4SCHDoNbnnfhmGSLVRCLNBUuGecxdvobSGmWMh", result.Result[0].PublicKey);
+
+            Assert.AreEqual("NhOiFR2mEcZJFj1ciaG2IrWOf2poe4LNGYC5gvdULBYyFH1Kq4cdNyYf+7u2r6NaWXHwnqiXnCzkFhIDU"
+                + "jSbNN2i/bmtSgasAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkpoamWb2mUaHqREQNm8VPcqSWUGCgPjWK"
+                + "jh0raCI+OEo8UAXpyc1w/8KV64XXwhGP70z6aN3K1vnzjpYXQqr3vvsgJ4UD4OatRY1IsR9NYTReSKpRIhPpTupzQ9W"
+                + "zTpfWSTLZP2xvdcWyo8spQGJ2uGX0jH9h4ZxJ+orI/IsnqxyAHH+MXZuMBl28YfgFJRh8PZHPKbmFvVPDFs3xgBVWzz"
+                + "QuNTAlY5aWAEN5CRqkYmOXDcge++gRlEry6ItrMEA0VZV0zsOFk2oDiT9W7slB3JefUOpWS4DMPJW6N0zRUDTtXaGmW"
+                + "rqt6W4vEGC0DnBI++A2ZkHoMmJ+qeCKBVkNJgAAADc4o2AAAAAA/w==", result.Result[0].Account.Data[0]);
+            Assert.AreEqual("base64", result.Result[0].Account.Data[1]);
+            Assert.AreEqual(false, result.Result[0].Account.Executable);
+            Assert.AreEqual(3486960UL, result.Result[0].Account.Lamports);
+            Assert.AreEqual("GrAkKfEpTKQuVHG2Y97Y2FF4i7y7Q5AHLK94JBy7Y5yv", result.Result[0].Account.Owner);
+            Assert.AreEqual(188UL, result.Result[0].Account.RentEpoch);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+
+        [TestMethod]
+        public void TestGetMultipleAccounts()
+        {
+            var responseData = File.ReadAllText("Resources/Http/Accounts/GetMultipleAccountsResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Accounts/GetMultipleAccountsRequest.json");
+
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var result = sut.GetMultipleAccounts(new List<string> { "Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu", "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5" });
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(2, result.Result.Value.Count);
+
+            Assert.AreEqual("base64", result.Result.Value[0].Data[1]);
+            Assert.AreEqual("", result.Result.Value[0].Data[0]);
+            Assert.AreEqual(false, result.Result.Value[0].Executable);
+            Assert.AreEqual(503668985208UL, result.Result.Value[0].Lamports);
+            Assert.AreEqual("11111111111111111111111111111111", result.Result.Value[0].Owner);
+            Assert.AreEqual(197UL, result.Result.Value[0].RentEpoch);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+    }
+}

--- a/test/Solnet.Rpc.Test/SolanaRpcClientBlockTests.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientBlockTests.cs
@@ -1,0 +1,508 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Solnet.Rpc.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Solnet.Rpc.Test
+{
+    public partial class SolanaRpcClientTest
+    {
+        [TestMethod]
+        public void TestGetBlock()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetBlock(79662905);
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(res.Result);
+            Assert.AreEqual(2, res.Result.Transactions.Length);
+
+            Assert.AreEqual(66130135, res.Result.BlockHeight);
+            Assert.AreEqual(1622632900, res.Result.BlockTime);
+            Assert.AreEqual(79662904UL, res.Result.ParentSlot);
+            Assert.AreEqual("5wLhsKAH9SCPbRZc4qWf3GBiod9CD8sCEZfMiU25qW8", res.Result.Blockhash);
+            Assert.AreEqual("CjJ97j84mUq3o67CEqzEkTifXpHLBCD8GvmfBYLz4Zdg", res.Result.PreviousBlockhash);
+
+            Assert.AreEqual(1, res.Result.Rewards.Length);
+            var rewards = res.Result.Rewards[0];
+
+            Assert.AreEqual(1785000, rewards.Lamports);
+            Assert.AreEqual(365762267923UL, rewards.PostBalance);
+            Assert.AreEqual("9zkU8suQBdhZVax2DSGNAnyEhEzfEELvA25CJhy5uwnW", rewards.Pubkey);
+            Assert.AreEqual(RewardType.Fee, rewards.RewardType);
+
+            TransactionMetaInfo first = res.Result.Transactions[0];
+
+            Assert.IsNotNull(first.Meta.Error);
+            Assert.AreEqual(TransactionErrorType.InstructionError, first.Meta.Error.Type);
+            Assert.IsNotNull(first.Meta.Error.InstructionError);
+            Assert.AreEqual(InstructionErrorType.Custom, first.Meta.Error.InstructionError.Type);
+            Assert.AreEqual(0, first.Meta.Error.InstructionError.CustomError);
+
+            Assert.AreEqual(5000UL, first.Meta.Fee);
+            Assert.AreEqual(0, first.Meta.InnerInstructions.Length);
+            Assert.AreEqual(2, first.Meta.LogMessages.Length);
+            Assert.AreEqual(5, first.Meta.PostBalances.Length);
+            Assert.AreEqual(35132731759UL, first.Meta.PostBalances[0]);
+            Assert.AreEqual(5, first.Meta.PreBalances.Length);
+            Assert.AreEqual(35132736759UL, first.Meta.PreBalances[0]);
+            Assert.AreEqual(0, first.Meta.PostTokenBalances.Length);
+            Assert.AreEqual(0, first.Meta.PreTokenBalances.Length);
+
+            Assert.AreEqual(1, first.Transaction.Signatures.Length);
+            Assert.AreEqual("2Hh35eZPP1wZLYQ1HHv8PqGoRo73XirJeKFpBVc19msi6qeJHk3yUKqS1viRtqkdb545CerTWeywPFXxjKEhDWTK", first.Transaction.Signatures[0]);
+
+            Assert.AreEqual(5, first.Transaction.Message.AccountKeys.Length);
+            Assert.AreEqual("DjuMPGThkGdyk2vDvDDYjTFSyxzTumdapnDNbvVZbYQE", first.Transaction.Message.AccountKeys[0]);
+
+            Assert.AreEqual(0, first.Transaction.Message.Header.NumReadonlySignedAccounts);
+            Assert.AreEqual(3, first.Transaction.Message.Header.NumReadonlyUnsignedAccounts);
+            Assert.AreEqual(1, first.Transaction.Message.Header.NumRequiredSignatures);
+
+            Assert.AreEqual(1, first.Transaction.Message.Instructions.Length);
+            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].Accounts.Length);
+            Assert.AreEqual("2ZjTR1vUs2pHXyTLxtFDhN2tsm2HbaH36cAxzJcwaXf8y5jdTESsGNBLFaxGuWENxLa2ZL3cX9foNJcWbRq", first.Transaction.Message.Instructions[0].Data);
+            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].ProgramIdIndex);
+
+            Assert.AreEqual("D8qh6AeX4KaTe6ZBpsZDdntTQUyPy7x6Xjp7NnEigCWH", first.Transaction.Message.RecentBlockhash);
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlockConfirmed()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetBlock(79662905, Types.Commitment.Confirmed);
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(res.Result);
+            Assert.AreEqual(2, res.Result.Transactions.Length);
+            /// everything else was already validated above
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlockProductionNoArgs()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionNoArgsResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionNoArgsRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetBlockProduction();
+
+            Assert.AreEqual(requestData, sentMessage);
+
+            Assert.AreEqual(3, res.Result.Value.ByIdentity.Count);
+            Assert.AreEqual(79580256UL, res.Result.Value.Range.FirstSlot);
+            Assert.AreEqual(79712285UL, res.Result.Value.Range.LastSlot);
+
+            Assert.IsTrue(res.Result.Value.ByIdentity.ContainsKey("121cur1YFVPZSoKQGNyjNr9sZZRa3eX2bSuYjXHtKD6"));
+            Assert.AreEqual(60, res.Result.Value.ByIdentity["121cur1YFVPZSoKQGNyjNr9sZZRa3eX2bSuYjXHtKD6"][0]);
+
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlockProductionIdentity()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionIdentityResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionIdentityRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetBlockProduction("Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu");
+
+            Assert.AreEqual(requestData, sentMessage);
+
+            Assert.AreEqual(1, res.Result.Value.ByIdentity.Count);
+            Assert.AreEqual(79580256UL, res.Result.Value.Range.FirstSlot);
+            Assert.AreEqual(79712285UL, res.Result.Value.Range.LastSlot);
+
+            Assert.IsTrue(res.Result.Value.ByIdentity.ContainsKey("Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"));
+            Assert.AreEqual(96, res.Result.Value.ByIdentity["Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"][0]);
+
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlockProductionRangeStart()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionRangeStartResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionRangeStartRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetBlockProduction(79714135UL);
+
+            Assert.AreEqual(requestData, sentMessage);
+
+            Assert.AreEqual(35, res.Result.Value.ByIdentity.Count);
+            Assert.AreEqual(79714135UL, res.Result.Value.Range.FirstSlot);
+            Assert.AreEqual(79714275UL, res.Result.Value.Range.LastSlot);
+
+            Assert.IsTrue(res.Result.Value.ByIdentity.ContainsKey("123vij84ecQEKUvQ7gYMKxKwKF6PbYSzCzzURYA4xULY"));
+            Assert.AreEqual(4, res.Result.Value.ByIdentity["123vij84ecQEKUvQ7gYMKxKwKF6PbYSzCzzURYA4xULY"][0]);
+            Assert.AreEqual(3, res.Result.Value.ByIdentity["123vij84ecQEKUvQ7gYMKxKwKF6PbYSzCzzURYA4xULY"][1]);
+
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlockProductionIdentityRange()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionIdentityRangeResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionIdentityRangeRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetBlockProduction("Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu", 79000000UL, 79500000UL);
+
+            Assert.AreEqual(requestData, sentMessage);
+
+            Assert.AreEqual(1, res.Result.Value.ByIdentity.Count);
+            Assert.AreEqual(79000000UL, res.Result.Value.Range.FirstSlot);
+            Assert.AreEqual(79500000UL, res.Result.Value.Range.LastSlot);
+
+            Assert.IsTrue(res.Result.Value.ByIdentity.ContainsKey("Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"));
+            Assert.AreEqual(416, res.Result.Value.ByIdentity["Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"][0]);
+            Assert.AreEqual(341, res.Result.Value.ByIdentity["Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"][1]);
+
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetTransaction()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetTransactionResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetTransactionRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetTransaction("5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1");
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(res.Result);
+            Assert.AreEqual(79700345UL, res.Result.Slot);
+
+            Assert.AreEqual(1622655364, res.Result.BlockTime);
+
+            TransactionMetaInfo first = res.Result;
+
+            Assert.IsNull(first.Meta.Error);
+
+            Assert.AreEqual(5000UL, first.Meta.Fee);
+            Assert.AreEqual(0, first.Meta.InnerInstructions.Length);
+            Assert.AreEqual(2, first.Meta.LogMessages.Length);
+            Assert.AreEqual(5, first.Meta.PostBalances.Length);
+            Assert.AreEqual(395383573380UL, first.Meta.PostBalances[0]);
+            Assert.AreEqual(5, first.Meta.PreBalances.Length);
+            Assert.AreEqual(395383578380UL, first.Meta.PreBalances[0]);
+            Assert.AreEqual(0, first.Meta.PostTokenBalances.Length);
+            Assert.AreEqual(0, first.Meta.PreTokenBalances.Length);
+
+            Assert.AreEqual(1, first.Transaction.Signatures.Length);
+            Assert.AreEqual("5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1", first.Transaction.Signatures[0]);
+
+            Assert.AreEqual(5, first.Transaction.Message.AccountKeys.Length);
+            Assert.AreEqual("EvVrzsxoj118sxxSTrcnc9u3fRdQfCc7d4gRzzX6TSqj", first.Transaction.Message.AccountKeys[0]);
+
+            Assert.AreEqual(0, first.Transaction.Message.Header.NumReadonlySignedAccounts);
+            Assert.AreEqual(3, first.Transaction.Message.Header.NumReadonlyUnsignedAccounts);
+            Assert.AreEqual(1, first.Transaction.Message.Header.NumRequiredSignatures);
+
+            Assert.AreEqual(1, first.Transaction.Message.Instructions.Length);
+            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].Accounts.Length);
+            Assert.AreEqual("2kr3BYaDkghC7rvHsQYnBNoB4dhXrUmzgYMM4kbHSG7ALa3qsMPxfC9cJTFDKyJaC8VYSjrey9pvyRivtESUJrC3qzr89pvS2o6MQ"
+                + "hyRVxmh3raQStxFFYwZ6WyKFNoQXvcchBwy8uQGfhhUqzuLNREwRmZ5U2VgTjFWX8Vikqya6iyzvALQNZEvqz7ZoGEyRtJ6AzNyWbkUyEo63rZ5w3wnxmhr3Uood",
+                first.Transaction.Message.Instructions[0].Data);
+
+            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].ProgramIdIndex);
+
+            Assert.AreEqual("6XGYfEJ5CGGBA5E8E7Gw4ToyDLDNNAyUCb7CJj1rLk21", first.Transaction.Message.RecentBlockhash);
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlocks()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlocksResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlocksRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetBlocks(79_499_950, 79_500_000);
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(res.Result);
+            Assert.AreEqual(39, res.Result.Count);
+            Assert.AreEqual(79499950UL, res.Result[0]);
+            Assert.AreEqual(79500000UL, res.Result[38]);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlocksWithLimit()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlocksWithLimitResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlocksWithLimitRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetBlocksWithLimit(79_699_950, 2);
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(res.Result);
+            Assert.AreEqual(2, res.Result.Count);
+            Assert.AreEqual(79699950UL, res.Result[0]);
+            Assert.AreEqual(79699951UL, res.Result[1]);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetFirstAvailableBlock()
+        {
+
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetFirstAvailableBlockResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetFirstAvailableBlockRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetFirstAvailableBlock();
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(res.Result);
+            Assert.AreEqual(39368303UL, res.Result);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlockHeight()
+        {
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockHeightResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockHeightRequest.json");
+
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var result = sut.GetBlockHeight();
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(1233UL, result.Result);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlockCommitment()
+        {
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockCommitmentResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockCommitmentRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+            var result = sut.GetBlockCommitment(78561320);
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(null, result.Result.Commitment);
+            Assert.AreEqual(78380558524696194UL, result.Result.TotalStake);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetBlockTime()
+        {
+            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockTimeResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockTimeRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+            var result = sut.GetBlockTime(78561320);
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(1621971949UL, result.Result);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetFeeCalculatorForBlockhash()
+        {
+            var responseData = File.ReadAllText("Resources/Http/GetFeeCalculatorForBlockhashResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/GetFeeCalculatorForBlockhashRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+            var result = sut.GetFeeCalculatorForBlockhash("GJxqhuxcgfn5Tcj6y3f8X4FeCDd2RQ6SnEMo1AAxrPRZ");
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(221UL, result.Result.Context.Slot);
+            Assert.AreEqual(5000UL, result.Result.Value.FeeCalculator.LamportsPerSignature);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        [TestMethod]
+        public void TestGetRecentBlockHash()
+        {
+            var responseData = File.ReadAllText("Resources/Http/GetRecentBlockhashResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/GetRecentBlockhashRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+            var result = sut.GetRecentBlockHash();
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(79206433UL, result.Result.Context.Slot);
+            Assert.AreEqual("FJGZeJiYkwCZCnFbGujHxfVGnFgrgZiomczHr247Tn2p", result.Result.Value.Blockhash);
+            Assert.AreEqual(5000UL, result.Result.Value.FeeCalculator.LamportsPerSignature);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+    }
+}

--- a/test/Solnet.Rpc.Test/SolanaRpcClientTest.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientTest.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 namespace Solnet.Rpc.Test
 {
     [TestClass]
-    public class SolanaRpcClientTest
+    public partial class SolanaRpcClientTest
     {
         private const string TestnetUrl = "https://testnet.solana.com";
         private static readonly Uri TestnetUri = new Uri(TestnetUrl);
@@ -121,7 +121,6 @@ namespace Solnet.Rpc.Test
             Assert.IsFalse(result.WasRequestSuccessfullyHandled);
         }
 
-
         [TestMethod]
         public void TestBadAddress2ExceptionRequest()
         {
@@ -152,167 +151,6 @@ namespace Solnet.Rpc.Test
             Assert.IsFalse(result.WasRequestSuccessfullyHandled);
         }
 
-
-        [TestMethod]
-        public void TestGetAccountInfo()
-        {
-            var responseData = File.ReadAllText("Resources/Http/Accounts/GetAccountInfoResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Accounts/GetAccountInfoRequest.json");
-
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri,
-            };
-
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var result = sut.GetAccountInfo("9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(result.Result);
-            Assert.IsTrue(result.WasSuccessful);
-            Assert.AreEqual(79200467UL, result.Result.Context.Slot);
-            Assert.AreEqual("", result.Result.Value.Data[0]);
-            Assert.AreEqual("base64", result.Result.Value.Data[1]);
-            Assert.AreEqual(false, result.Result.Value.Executable);
-            Assert.AreEqual(5478840UL, result.Result.Value.Lamports);
-            Assert.AreEqual("11111111111111111111111111111111", result.Result.Value.Owner);
-            Assert.AreEqual(195UL, result.Result.Value.RentEpoch);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-
-        [TestMethod]
-        public void TestGetProgramAccounts()
-        {
-            var responseData = File.ReadAllText("Resources/Http/Accounts/GetProgramAccountsResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Accounts/GetProgramAccountsRequest.json");
-
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri,
-            };
-
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var result = sut.GetProgramAccounts("GrAkKfEpTKQuVHG2Y97Y2FF4i7y7Q5AHLK94JBy7Y5yv");
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(result.Result);
-            Assert.IsTrue(result.WasSuccessful);
-            Assert.AreEqual(2, result.Result.Count);
-            Assert.AreEqual("FzNKvS4SCHDoNbnnfhmGSLVRCLNBUuGecxdvobSGmWMh", result.Result[0].PublicKey);
-
-            Assert.AreEqual("NhOiFR2mEcZJFj1ciaG2IrWOf2poe4LNGYC5gvdULBYyFH1Kq4cdNyYf+7u2r6NaWXHwnqiXnCzkFhIDU"
-                + "jSbNN2i/bmtSgasAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkpoamWb2mUaHqREQNm8VPcqSWUGCgPjWK"
-                + "jh0raCI+OEo8UAXpyc1w/8KV64XXwhGP70z6aN3K1vnzjpYXQqr3vvsgJ4UD4OatRY1IsR9NYTReSKpRIhPpTupzQ9W"
-                + "zTpfWSTLZP2xvdcWyo8spQGJ2uGX0jH9h4ZxJ+orI/IsnqxyAHH+MXZuMBl28YfgFJRh8PZHPKbmFvVPDFs3xgBVWzz"
-                + "QuNTAlY5aWAEN5CRqkYmOXDcge++gRlEry6ItrMEA0VZV0zsOFk2oDiT9W7slB3JefUOpWS4DMPJW6N0zRUDTtXaGmW"
-                + "rqt6W4vEGC0DnBI++A2ZkHoMmJ+qeCKBVkNJgAAADc4o2AAAAAA/w==", result.Result[0].Account.Data[0]);
-            Assert.AreEqual("base64", result.Result[0].Account.Data[1]);
-            Assert.AreEqual(false, result.Result[0].Account.Executable);
-            Assert.AreEqual(3486960UL, result.Result[0].Account.Lamports);
-            Assert.AreEqual("GrAkKfEpTKQuVHG2Y97Y2FF4i7y7Q5AHLK94JBy7Y5yv", result.Result[0].Account.Owner);
-            Assert.AreEqual(188UL, result.Result[0].Account.RentEpoch);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-
-        [TestMethod]
-        public void TestGetMultipleAccounts()
-        {
-            var responseData = File.ReadAllText("Resources/Http/Accounts/GetMultipleAccountsResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Accounts/GetMultipleAccountsRequest.json");
-
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri,
-            };
-
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var result = sut.GetMultipleAccounts(new List<string> { "Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu", "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5" });
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(result.Result);
-            Assert.IsTrue(result.WasSuccessful);
-            Assert.AreEqual(2, result.Result.Value.Count);
-
-            Assert.AreEqual("base64", result.Result.Value[0].Data[1]);
-            Assert.AreEqual("", result.Result.Value[0].Data[0]);
-            Assert.AreEqual(false, result.Result.Value[0].Executable);
-            Assert.AreEqual(503668985208UL, result.Result.Value[0].Lamports);
-            Assert.AreEqual("11111111111111111111111111111111", result.Result.Value[0].Owner);
-            Assert.AreEqual(197UL, result.Result.Value[0].RentEpoch);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-
-
-        [TestMethod]
-        public void TestGetBlockHeight()
-        {
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockHeightResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockHeightRequest.json");
-
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri,
-            };
-
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var result = sut.GetBlockHeight();
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(result);
-            Assert.IsTrue(result.WasSuccessful);
-            Assert.AreEqual(1233UL, result.Result);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
-        public void TestGetBlockCommitment()
-        {
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockCommitmentResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockCommitmentRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri,
-            };
-
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-            var result = sut.GetBlockCommitment(78561320);
-
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(result.Result);
-            Assert.IsTrue(result.WasSuccessful);
-            Assert.AreEqual(null, result.Result.Commitment);
-            Assert.AreEqual(78380558524696194UL, result.Result.TotalStake);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
         [TestMethod]
         public void TestGetBalance()
         {
@@ -340,10 +178,10 @@ namespace Solnet.Rpc.Test
         }
 
         [TestMethod]
-        public void TestGetBlockTime()
+        public void TestGetBalanceConfirmed()
         {
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockTimeResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockTimeRequest.json");
+            var responseData = File.ReadAllText("Resources/Http/GetBalanceResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/GetBalanceConfirmedRequest.json");
             var sentMessage = string.Empty;
             var messageHandlerMock = SetupTest(
                 (s => sentMessage = s), responseData);
@@ -354,12 +192,13 @@ namespace Solnet.Rpc.Test
             };
 
             var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-            var result = sut.GetBlockTime(78561320);
+            var result = sut.GetBalance("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh", Types.Commitment.Confirmed);
 
             Assert.AreEqual(requestData, sentMessage);
             Assert.IsNotNull(result.Result);
             Assert.IsTrue(result.WasSuccessful);
-            Assert.AreEqual(1621971949UL, result.Result);
+            Assert.AreEqual(79274779UL, result.Result.Context.Slot);
+            Assert.AreEqual(168855000000UL, result.Result.Value);
 
             FinishTest(messageHandlerMock, TestnetUri);
         }
@@ -425,7 +264,6 @@ namespace Solnet.Rpc.Test
             FinishTest(messageHandlerMock, TestnetUri);
         }
 
-
         [TestMethod]
         public void TestGetEpochSchedule()
         {
@@ -451,32 +289,6 @@ namespace Solnet.Rpc.Test
             Assert.AreEqual(8192UL, result.Result.LeaderScheduleSlotOffset);
             Assert.AreEqual(8192UL, result.Result.SlotsPerEpoch);
             Assert.AreEqual(true, result.Result.Warmup);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
-        public void TestGetFeeCalculatorForBlockhash()
-        {
-            var responseData = File.ReadAllText("Resources/Http/GetFeeCalculatorForBlockhashResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/GetFeeCalculatorForBlockhashRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri,
-            };
-
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-            var result = sut.GetFeeCalculatorForBlockhash("GJxqhuxcgfn5Tcj6y3f8X4FeCDd2RQ6SnEMo1AAxrPRZ");
-
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(result.Result);
-            Assert.IsTrue(result.WasSuccessful);
-            Assert.AreEqual(221UL, result.Result.Context.Slot);
-            Assert.AreEqual(5000UL, result.Result.Value.FeeCalculator.LamportsPerSignature);
 
             FinishTest(messageHandlerMock, TestnetUri);
         }
@@ -798,33 +610,6 @@ namespace Solnet.Rpc.Test
         }
 
         [TestMethod]
-        public void TestGetRecentBlockHash()
-        {
-            var responseData = File.ReadAllText("Resources/Http/GetRecentBlockhashResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/GetRecentBlockhashRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri,
-            };
-
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-            var result = sut.GetRecentBlockHash();
-
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(result.Result);
-            Assert.IsTrue(result.WasSuccessful);
-            Assert.AreEqual(79206433UL, result.Result.Context.Slot);
-            Assert.AreEqual("FJGZeJiYkwCZCnFbGujHxfVGnFgrgZiomczHr247Tn2p", result.Result.Value.Blockhash);
-            Assert.AreEqual(5000UL, result.Result.Value.FeeCalculator.LamportsPerSignature);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
         public void TestGetSlotLeadersEmpty()
         {
             var responseData = File.ReadAllText("Resources/Http/GetSlotLeadersEmptyResponse.json");
@@ -1083,7 +868,6 @@ namespace Solnet.Rpc.Test
 
             FinishTest(messageHandlerMock, TestnetUri);
         }
-
 
         [TestMethod]
         public void TestGetSignatureStatusesWithHistory()
@@ -1608,144 +1392,6 @@ namespace Solnet.Rpc.Test
             FinishTest(messageHandlerMock, TestnetUri);
         }
 
-        [TestMethod]
-        public void TestGetTransaction()
-        {
-
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetTransactionResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetTransactionRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri
-            };
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var res = sut.GetTransaction("5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1");
-
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(res.Result);
-            Assert.AreEqual(79700345UL, res.Result.Slot);
-
-            Assert.AreEqual(1622655364, res.Result.BlockTime);
-
-            TransactionMetaInfo first = res.Result;
-
-            Assert.IsNull(first.Meta.Error);
-
-            Assert.AreEqual(5000UL, first.Meta.Fee);
-            Assert.AreEqual(0, first.Meta.InnerInstructions.Length);
-            Assert.AreEqual(2, first.Meta.LogMessages.Length);
-            Assert.AreEqual(5, first.Meta.PostBalances.Length);
-            Assert.AreEqual(395383573380UL, first.Meta.PostBalances[0]);
-            Assert.AreEqual(5, first.Meta.PreBalances.Length);
-            Assert.AreEqual(395383578380UL, first.Meta.PreBalances[0]);
-            Assert.AreEqual(0, first.Meta.PostTokenBalances.Length);
-            Assert.AreEqual(0, first.Meta.PreTokenBalances.Length);
-
-            Assert.AreEqual(1, first.Transaction.Signatures.Length);
-            Assert.AreEqual("5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1", first.Transaction.Signatures[0]);
-
-            Assert.AreEqual(5, first.Transaction.Message.AccountKeys.Length);
-            Assert.AreEqual("EvVrzsxoj118sxxSTrcnc9u3fRdQfCc7d4gRzzX6TSqj", first.Transaction.Message.AccountKeys[0]);
-
-            Assert.AreEqual(0, first.Transaction.Message.Header.NumReadonlySignedAccounts);
-            Assert.AreEqual(3, first.Transaction.Message.Header.NumReadonlyUnsignedAccounts);
-            Assert.AreEqual(1, first.Transaction.Message.Header.NumRequiredSignatures);
-
-            Assert.AreEqual(1, first.Transaction.Message.Instructions.Length);
-            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].Accounts.Length);
-            Assert.AreEqual("2kr3BYaDkghC7rvHsQYnBNoB4dhXrUmzgYMM4kbHSG7ALa3qsMPxfC9cJTFDKyJaC8VYSjrey9pvyRivtESUJrC3qzr89pvS2o6MQ"
-                + "hyRVxmh3raQStxFFYwZ6WyKFNoQXvcchBwy8uQGfhhUqzuLNREwRmZ5U2VgTjFWX8Vikqya6iyzvALQNZEvqz7ZoGEyRtJ6AzNyWbkUyEo63rZ5w3wnxmhr3Uood",
-                first.Transaction.Message.Instructions[0].Data);
-
-            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].ProgramIdIndex);
-
-            Assert.AreEqual("6XGYfEJ5CGGBA5E8E7Gw4ToyDLDNNAyUCb7CJj1rLk21", first.Transaction.Message.RecentBlockhash);
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
-        public void TestGetBlocks()
-        {
-
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlocksResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlocksRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri
-            };
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var res = sut.GetBlocks(79_499_950, 79_500_000);
-
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(res.Result);
-            Assert.AreEqual(39, res.Result.Count);
-            Assert.AreEqual(79499950UL, res.Result[0]);
-            Assert.AreEqual(79500000UL, res.Result[38]);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
-        public void TestGetBlocksWithLimit()
-        {
-
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlocksWithLimitResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlocksWithLimitRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri
-            };
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var res = sut.GetBlocksWithLimit(79_699_950, 2);
-
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(res.Result);
-            Assert.AreEqual(2, res.Result.Count);
-            Assert.AreEqual(79699950UL, res.Result[0]);
-            Assert.AreEqual(79699951UL, res.Result[1]);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
-        public void TestGetFirstAvailableBlock()
-        {
-
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetFirstAvailableBlockResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetFirstAvailableBlockRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri
-            };
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var res = sut.GetFirstAvailableBlock();
-
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(res.Result);
-            Assert.AreEqual(39368303UL, res.Result);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
 
         [TestMethod]
         public void TestGetHealth_HealthyResponse()
@@ -1919,207 +1565,6 @@ namespace Solnet.Rpc.Test
 
             Assert.AreEqual(7, res.Result["4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F"].Count);
             Assert.AreEqual(0UL, res.Result["4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F"][0]);
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-
-
-        [TestMethod]
-        public void TestGetBlock()
-        {
-
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri
-            };
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var res = sut.GetBlock(79662905);
-
-            Assert.AreEqual(requestData, sentMessage);
-            Assert.IsNotNull(res.Result);
-            Assert.AreEqual(2, res.Result.Transactions.Length);
-
-            Assert.AreEqual(66130135, res.Result.BlockHeight);
-            Assert.AreEqual(1622632900, res.Result.BlockTime);
-            Assert.AreEqual(79662904UL, res.Result.ParentSlot);
-            Assert.AreEqual("5wLhsKAH9SCPbRZc4qWf3GBiod9CD8sCEZfMiU25qW8", res.Result.Blockhash);
-            Assert.AreEqual("CjJ97j84mUq3o67CEqzEkTifXpHLBCD8GvmfBYLz4Zdg", res.Result.PreviousBlockhash);
-
-            Assert.AreEqual(1, res.Result.Rewards.Length);
-            var rewards = res.Result.Rewards[0];
-
-            Assert.AreEqual(1785000, rewards.Lamports);
-            Assert.AreEqual(365762267923UL, rewards.PostBalance);
-            Assert.AreEqual("9zkU8suQBdhZVax2DSGNAnyEhEzfEELvA25CJhy5uwnW", rewards.Pubkey);
-            Assert.AreEqual(RewardType.Fee, rewards.RewardType);
-
-            TransactionMetaInfo first = res.Result.Transactions[0];
-
-            Assert.IsNotNull(first.Meta.Error);
-            Assert.AreEqual(TransactionErrorType.InstructionError, first.Meta.Error.Type);
-            Assert.IsNotNull(first.Meta.Error.InstructionError);
-            Assert.AreEqual(InstructionErrorType.Custom, first.Meta.Error.InstructionError.Type);
-            Assert.AreEqual(0, first.Meta.Error.InstructionError.CustomError);
-
-            Assert.AreEqual(5000UL, first.Meta.Fee);
-            Assert.AreEqual(0, first.Meta.InnerInstructions.Length);
-            Assert.AreEqual(2, first.Meta.LogMessages.Length);
-            Assert.AreEqual(5, first.Meta.PostBalances.Length);
-            Assert.AreEqual(35132731759UL, first.Meta.PostBalances[0]);
-            Assert.AreEqual(5, first.Meta.PreBalances.Length);
-            Assert.AreEqual(35132736759UL, first.Meta.PreBalances[0]);
-            Assert.AreEqual(0, first.Meta.PostTokenBalances.Length);
-            Assert.AreEqual(0, first.Meta.PreTokenBalances.Length);
-
-            Assert.AreEqual(1, first.Transaction.Signatures.Length);
-            Assert.AreEqual("2Hh35eZPP1wZLYQ1HHv8PqGoRo73XirJeKFpBVc19msi6qeJHk3yUKqS1viRtqkdb545CerTWeywPFXxjKEhDWTK", first.Transaction.Signatures[0]);
-
-            Assert.AreEqual(5, first.Transaction.Message.AccountKeys.Length);
-            Assert.AreEqual("DjuMPGThkGdyk2vDvDDYjTFSyxzTumdapnDNbvVZbYQE", first.Transaction.Message.AccountKeys[0]);
-
-            Assert.AreEqual(0, first.Transaction.Message.Header.NumReadonlySignedAccounts);
-            Assert.AreEqual(3, first.Transaction.Message.Header.NumReadonlyUnsignedAccounts);
-            Assert.AreEqual(1, first.Transaction.Message.Header.NumRequiredSignatures);
-
-            Assert.AreEqual(1, first.Transaction.Message.Instructions.Length);
-            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].Accounts.Length);
-            Assert.AreEqual("2ZjTR1vUs2pHXyTLxtFDhN2tsm2HbaH36cAxzJcwaXf8y5jdTESsGNBLFaxGuWENxLa2ZL3cX9foNJcWbRq", first.Transaction.Message.Instructions[0].Data);
-            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].ProgramIdIndex);
-
-            Assert.AreEqual("D8qh6AeX4KaTe6ZBpsZDdntTQUyPy7x6Xjp7NnEigCWH", first.Transaction.Message.RecentBlockhash);
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
-        public void TestGetBlockProductionNoArgs()
-        {
-
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionNoArgsResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionNoArgsRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri
-            };
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var res = sut.GetBlockProduction();
-
-            Assert.AreEqual(requestData, sentMessage);
-
-            Assert.AreEqual(3, res.Result.Value.ByIdentity.Count);
-            Assert.AreEqual(79580256UL, res.Result.Value.Range.FirstSlot);
-            Assert.AreEqual(79712285UL, res.Result.Value.Range.LastSlot);
-
-            Assert.IsTrue(res.Result.Value.ByIdentity.ContainsKey("121cur1YFVPZSoKQGNyjNr9sZZRa3eX2bSuYjXHtKD6"));
-            Assert.AreEqual(60, res.Result.Value.ByIdentity["121cur1YFVPZSoKQGNyjNr9sZZRa3eX2bSuYjXHtKD6"][0]);
-
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
-        public void TestGetBlockProductionIdentity()
-        {
-
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionIdentityResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionIdentityRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri
-            };
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var res = sut.GetBlockProduction("Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu");
-
-            Assert.AreEqual(requestData, sentMessage);
-
-            Assert.AreEqual(1, res.Result.Value.ByIdentity.Count);
-            Assert.AreEqual(79580256UL, res.Result.Value.Range.FirstSlot);
-            Assert.AreEqual(79712285UL, res.Result.Value.Range.LastSlot);
-
-            Assert.IsTrue(res.Result.Value.ByIdentity.ContainsKey("Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"));
-            Assert.AreEqual(96, res.Result.Value.ByIdentity["Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"][0]);
-
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
-        public void TestGetBlockProductionRangeStart()
-        {
-
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionRangeStartResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionRangeStartRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri
-            };
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var res = sut.GetBlockProduction(79714135UL);
-
-            Assert.AreEqual(requestData, sentMessage);
-
-            Assert.AreEqual(35, res.Result.Value.ByIdentity.Count);
-            Assert.AreEqual(79714135UL, res.Result.Value.Range.FirstSlot);
-            Assert.AreEqual(79714275UL, res.Result.Value.Range.LastSlot);
-
-            Assert.IsTrue(res.Result.Value.ByIdentity.ContainsKey("123vij84ecQEKUvQ7gYMKxKwKF6PbYSzCzzURYA4xULY"));
-            Assert.AreEqual(4, res.Result.Value.ByIdentity["123vij84ecQEKUvQ7gYMKxKwKF6PbYSzCzzURYA4xULY"][0]);
-            Assert.AreEqual(3, res.Result.Value.ByIdentity["123vij84ecQEKUvQ7gYMKxKwKF6PbYSzCzzURYA4xULY"][1]);
-
-
-            FinishTest(messageHandlerMock, TestnetUri);
-        }
-
-        [TestMethod]
-        public void TestGetBlockProductionIdentityRange()
-        {
-
-            var responseData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionIdentityRangeResponse.json");
-            var requestData = File.ReadAllText("Resources/Http/Blocks/GetBlockProductionIdentityRangeRequest.json");
-            var sentMessage = string.Empty;
-            var messageHandlerMock = SetupTest(
-                (s => sentMessage = s), responseData);
-
-            var httpClient = new HttpClient(messageHandlerMock.Object)
-            {
-                BaseAddress = TestnetUri
-            };
-            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
-
-            var res = sut.GetBlockProduction("Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu", 79000000UL, 79500000UL);
-
-            Assert.AreEqual(requestData, sentMessage);
-
-            Assert.AreEqual(1, res.Result.Value.ByIdentity.Count);
-            Assert.AreEqual(79000000UL, res.Result.Value.Range.FirstSlot);
-            Assert.AreEqual(79500000UL, res.Result.Value.Range.LastSlot);
-
-            Assert.IsTrue(res.Result.Value.ByIdentity.ContainsKey("Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"));
-            Assert.AreEqual(416, res.Result.Value.ByIdentity["Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"][0]);
-            Assert.AreEqual(341, res.Result.Value.ByIdentity["Bbe9EKucmRtJr2J4dd5Eb5ybQmY7Fm7jYxKXxmmkLFsu"][1]);
-
 
             FinishTest(messageHandlerMock, TestnetUri);
         }

--- a/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
+++ b/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
@@ -24,6 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Resources\Http\Accounts\GetAccountInfoConfirmedRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Http\Accounts\GetProgramAccountsRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -57,6 +60,9 @@
     <None Update="Resources\Http\Blocks\GetBlockProductionIdentityResponse.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Http\Blocks\GetBlockConfirmedRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Http\Blocks\GetFirstAvailableBlockRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -88,6 +94,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\Http\Blocks\GetBlockResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Http\GetBalanceConfirmedRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\Http\Health\GetHealthUnhealthyResponse.json">


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes | Closes #78  |

## Problem

_What problem are you trying to solve?_
Missing commitment parameters.

## Solution

_How did you solve the problem?_
Added commitment parameters to some methods.
Refactoring the tests to avoid a single unit test file with a billion LoC.
Removed sending default parameter from "transactionDetails" from GetBlock method.