### PR TITLE
Improving keystore to allow restoring wallet from string byte array

### DIFF
--- a/src/Solnet.KeyStore/SolanaKeyStore.cs
+++ b/src/Solnet.KeyStore/SolanaKeyStore.cs
@@ -9,30 +9,25 @@ namespace Solnet.KeyStore
     /// </summary>
     public class SolanaKeyStoreService
     {
+        /// <summary>
+        /// Restores a keypair from a keystore compatible with the solana-keygen made in rust.
+        /// </summary>
+        /// <param name="privateKey">The string with the private key bytes.</param>
+        /// <param name="passphrase">The passphrase used while originally generating the keys.</param>
+        public Wallet.Wallet RestoreKeystore(string privateKey, string passphrase = "")
+        {
+            return InitializeWallet(privateKey.FromStringByteArray(), passphrase);
+        }
 
         /// <summary>
         /// Restores a keypair from a keystore compatible with the solana-keygen made in rust.
         /// </summary>
         /// <param name="path">The path to the keystore.</param>
         /// <param name="passphrase">The passphrase used while originally generating the keys.</param>
-        public Wallet.Wallet RestoreKeystore(string path, string passphrase = "")
+        public Wallet.Wallet RestoreKeystoreFromFile(string path, string passphrase = "")
         {
             var inputBytes = File.ReadAllText(path).FromStringByteArray();
-
-            var wallet = new Wallet.Wallet(inputBytes, passphrase, SeedMode.Bip39);
-
-            return wallet;
-        }
-
-        /// <summary>
-        /// NOT IMPLEMENTED.
-        /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
-        /// <exception cref="System.NotImplementedException">NOT IMPLEMENTED.</exception>
-        public Wallet.Wallet DecryptAndRestoreKeystore(string path)
-        {
-            throw new System.NotImplementedException();
+            return InitializeWallet(inputBytes, passphrase);
         }
 
         /// <summary>
@@ -46,14 +41,14 @@ namespace Solnet.KeyStore
         }
 
         /// <summary>
-        /// NOT IMPLEMENTED.
+        /// Initialize the wallet.
         /// </summary>
-        /// <param name="path"></param>
-        /// <param name="wallet">The wallet to save to the keystore.</param>
-        /// <exception cref="System.NotImplementedException">NOT IMPLEMENTED.</exception>
-        public void EncryptAndSaveKeystore(string path, Wallet.Wallet wallet)
+        /// <param name="seed">The seed.</param>
+        /// <param name="passphrase">The passphrase.</param>
+        /// <returns>The wallet.</returns>
+        private Wallet.Wallet InitializeWallet(byte[] seed, string passphrase = "")
         {
-            throw new System.NotImplementedException();
+            return new Wallet.Wallet(seed, passphrase, SeedMode.Bip39);
         }
     }
 }

--- a/test/Solnet.KeyStore.Test/SolanaKeygenKeyStoreTest.cs
+++ b/test/Solnet.KeyStore.Test/SolanaKeygenKeyStoreTest.cs
@@ -8,6 +8,8 @@ namespace Solnet.KeyStore.Test
     [TestClass]
     public class SolanaKeygenKeyStoreTest
     {
+        private static readonly SolanaKeyStoreService KeyStoreService = new();
+
         private const string InvalidPath = "Resources/DoesNotExist.txt";
         private const string InvalidEmptyFilePath = "Resources/InvalidEmptyFile.txt";
         private const string ValidKeyStorePath = "Resources/ValidSolanaKeygenKeyStore.txt";
@@ -15,6 +17,10 @@ namespace Solnet.KeyStore.Test
         private const string ValidKeyStoreSavePath = "Resources/ValidSolanaKeygenSave.txt";
 
         private const string ExpectedKeyStoreAddress = "4n8BE7DHH4NudifUBrwPbvNPs2F86XcagT7C2JKdrWrR";
+
+        private const string StringKeyStoreSeedWithoutPassphrase =
+            "[69,191,12,22,125,16,119,72,240,150,74,197,249,221,54,164,172,222,248,202,22,242,96,43,105,164,101,52,155,41,46,6,107,27,120,68,31,183,113,110,148,151,206,38,195,198,108,78,97,66,196,191,82,41,240,33,253,9,89,19,75,196,171,104]";
+        private const string ExpectedStringKeyStoreAddress = "8D6vFRiysWWBwuf3HY7RrPt8EiFoP9o94LzySZqD4HsV";
 
         private static readonly byte[] SeedWithPassphrase =
         {
@@ -30,23 +36,20 @@ namespace Solnet.KeyStore.Test
         [ExpectedException(typeof(FileNotFoundException))]
         public void TestKeyStoreFileNotFound()
         {
-            var keyStore = new SolanaKeyStoreService();
-            _ = keyStore.RestoreKeystore(InvalidPath);
+            _ = KeyStoreService.RestoreKeystoreFromFile(InvalidPath);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void TestKeyStoreInvalidEmptyFilePath()
         {
-            var keyStore = new SolanaKeyStoreService();
-            _ = keyStore.RestoreKeystore(InvalidEmptyFilePath);
+            _ = KeyStoreService.RestoreKeystoreFromFile(InvalidEmptyFilePath);
         }
 
         [TestMethod]
         public void TestKeyStoreValid()
         {
-            var keyStore = new SolanaKeyStoreService();
-            var wallet = keyStore.RestoreKeystore(ValidKeyStorePath);
+            var wallet = KeyStoreService.RestoreKeystoreFromFile(ValidKeyStorePath);
 
             Assert.AreEqual(wallet.Account.GetPublicKey, ExpectedKeyStoreAddress);
         }
@@ -55,37 +58,26 @@ namespace Solnet.KeyStore.Test
         [ExpectedException(typeof(ArgumentException))]
         public void TestKeyStoreInvalid()
         {
-            var keyStore = new SolanaKeyStoreService();
-            _ = keyStore.RestoreKeystore(InvalidKeyStorePath);
+            _ = KeyStoreService.RestoreKeystoreFromFile(InvalidKeyStorePath);
         }
 
         [TestMethod]
         public void TestKeyStoreFull()
         {
-            var keyStore = new SolanaKeyStoreService();
             var walletToSave = new Wallet.Wallet(SeedWithPassphrase, "bip39passphrase", SeedMode.Bip39);
-            keyStore.SaveKeystore(ValidKeyStoreSavePath, walletToSave);
-            var restoredWallet = keyStore.RestoreKeystore(ValidKeyStorePath, "bip39passphrase");
+            KeyStoreService.SaveKeystore(ValidKeyStoreSavePath, walletToSave);
+            var restoredWallet = KeyStoreService.RestoreKeystoreFromFile(ValidKeyStorePath, "bip39passphrase");
 
             Assert.AreEqual(ExpectedKeyStoreAddress, walletToSave.Account.GetPublicKey);
             Assert.AreEqual(ExpectedKeyStoreAddress, restoredWallet.Account.GetPublicKey);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(NotImplementedException))]
-        public void TestKeyStoreDecryptNotImplemented()
+        public void TestRestoreKeyStore()
         {
-
-            var keyStore = new SolanaKeyStoreService();
-            _ = keyStore.DecryptAndRestoreKeystore("Some/Path");
+            var wallet = KeyStoreService.RestoreKeystore(StringKeyStoreSeedWithoutPassphrase);
+            Assert.AreEqual(ExpectedStringKeyStoreAddress, wallet.Account.GetPublicKey);
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(NotImplementedException))]
-        public void TestKeyStoreEncryptNotImplemented()
-        {
-            var keyStore = new SolanaKeyStoreService();
-            keyStore.EncryptAndSaveKeystore("Some/Path", new Wallet.Wallet(SeedWithPassphrase));
-        }
     }
 }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Refactor | Yes | Closes #82 |

## Problem

_What problem are you trying to solve?_

The keystore compatible with the `solana-keygen` tool only allows to restore the wallet from the file.

## Solution

_How did you solve the problem?_

Changed the keystore to allow restoring from both a file and a string that represents the same contents that the file would have,
so users can import keys via applications (e.g. Sollet using import private key)
