### PR TITLE
Migrating System.Cryptography usage to BouncyCastle to allow web usage

### DIFF
--- a/src/Solnet.Rpc/Utilities/AddressExtensions.cs
+++ b/src/Solnet.Rpc/Utilities/AddressExtensions.cs
@@ -1,8 +1,8 @@
+using Org.BouncyCastle.Crypto.Digests;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 
 namespace Solnet.Rpc.Utilities
@@ -27,9 +27,9 @@ namespace Solnet.Rpc.Utilities
         /// <exception cref="Exception">Throws exception when the resulting address doesn't fall off the Ed25519 curve.</exception>
         public static byte[] CreateProgramAddress(IList<byte[]> seeds, byte[] programId)
         {
-            var buffer = new MemoryStream(32 * seeds.Count + ProgramDerivedAddressBytes.Length + programId.Length);
+            MemoryStream buffer = new (32 * seeds.Count + ProgramDerivedAddressBytes.Length + programId.Length);
 
-            foreach (var seed in seeds)
+            foreach (byte[] seed in seeds)
             {
                 if (seed.Length > 32)
                 {
@@ -42,7 +42,7 @@ namespace Solnet.Rpc.Utilities
             buffer.Write(programId);
             buffer.Write(ProgramDerivedAddressBytes);
 
-            var hash = SHA256.HashData(buffer.ToArray());
+            byte[] hash = Sha256(buffer.ToArray());
 
             if (hash.IsOnCurve())
             {
@@ -61,8 +61,8 @@ namespace Solnet.Rpc.Utilities
         /// <exception cref="Exception">Throws exception when it is unable to find a viable nonce for the address.</exception>
         public static (byte[] Address, int Nonce) FindProgramAddress(IEnumerable<byte[]> seeds, byte[] programId)
         {
-            var nonce = 255;
-            var buffer = seeds.ToList();
+            int nonce = 255;
+            List<byte[]> buffer = seeds.ToList();
 
             while (nonce-- != 0)
             {
@@ -82,6 +82,20 @@ namespace Solnet.Rpc.Utilities
             }
 
             throw new Exception("unable to find viable program address nonce");
+        }
+        
+        /// <summary>
+        /// Calculates the SHA256 of the given data.
+        /// </summary>
+        /// <param name="data">The data to hash.</param>
+        /// <returns>The hash.</returns>
+        private static byte[] Sha256(byte[] data)
+        {
+            byte[] i = new byte[32];
+            Sha256Digest digest = new ();
+            digest.BlockUpdate(data, 0, data.Length);
+            digest.DoFinal(i, 0);
+            return i;
         }
     }
 }

--- a/src/Solnet.Wallet/Account.cs
+++ b/src/Solnet.Wallet/Account.cs
@@ -1,7 +1,6 @@
 using Chaos.NaCl;
+using Org.BouncyCastle.Security;
 using Solnet.Wallet.Utilities;
-using System;
-using System.Security.Cryptography;
 
 namespace Solnet.Wallet
 {
@@ -81,7 +80,7 @@ namespace Solnet.Wallet
         private static byte[] GenerateRandomSeed()
         {
             byte[] bytes = new byte[Ed25519.PrivateKeySeedSizeInBytes];
-            RandomNumberGenerator.Create().GetBytes(bytes);
+            RandomUtils.GetBytes(bytes);
             return bytes;
         }
     }

--- a/src/Solnet.Wallet/Ed25519Bip32.cs
+++ b/src/Solnet.Wallet/Ed25519Bip32.cs
@@ -1,8 +1,10 @@
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Macs;
+using Org.BouncyCastle.Crypto.Parameters;
 using Solnet.Wallet.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -76,8 +78,13 @@ namespace Solnet.Wallet
         /// <returns>A tuple consisting of the key and corresponding chain code.</returns>
         private static (byte[] Key, byte[] ChainCode) HmacSha512(byte[] keyBuffer, byte[] data)
         {
-            using HMACSHA512 hmacSha512 = new (keyBuffer);
-            byte[] i = hmacSha512.ComputeHash(data);
+            byte[] i = new byte[64];
+            Sha512Digest digest = new ();
+            HMac hmac = new (digest);
+            
+            hmac.Init(new KeyParameter(keyBuffer));
+            hmac.BlockUpdate(data, 0, data.Length);
+            hmac.DoFinal(i, 0);
 
             byte[] il = i.Slice(0, 32);
             byte[] ir = i.Slice(32);

--- a/src/Solnet.Wallet/Solnet.Wallet.csproj
+++ b/src/Solnet.Wallet/Solnet.Wallet.csproj
@@ -12,6 +12,7 @@
       <_Parameter1>Solnet.Wallet.Test</_Parameter1>
     </AssemblyAttribute>
     <PackageReference Include="Chaos.NaCl.Standard" Version="1.0.0" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
   </ItemGroup>
 
   <Import Project="..\..\SharedBuildProperties.props"/>

--- a/src/Solnet.Wallet/Utilities/RandomUtils.cs
+++ b/src/Solnet.Wallet/Utilities/RandomUtils.cs
@@ -1,5 +1,5 @@
+using Org.BouncyCastle.Security;
 using System;
-using System.Security.Cryptography;
 
 namespace Solnet.Wallet.Utilities
 {
@@ -11,14 +11,14 @@ namespace Solnet.Wallet.Utilities
         /// <summary>
         /// The instance of the crypto service provider.
         /// </summary>
-        private readonly RNGCryptoServiceProvider _instance;
+        private readonly SecureRandom _instance;
 
         /// <summary>
         /// Initialize the random number generator.
         /// </summary>
         public RngCryptoServiceProviderRandom()
         {
-            _instance = new RNGCryptoServiceProvider();
+            _instance = new SecureRandom();
         }
 
         #region IRandom Members
@@ -26,7 +26,7 @@ namespace Solnet.Wallet.Utilities
         /// <inheritdoc cref="IRandom.GetBytes(byte[])"/>
         public void GetBytes(byte[] output)
         {
-            _instance.GetBytes(output);
+            _instance.NextBytes(output);
         }
 
         #endregion
@@ -86,6 +86,21 @@ namespace Solnet.Wallet.Utilities
             Random.GetBytes(data);
             PushEntropy(data);
             return data;
+        }
+        
+        /// <summary>
+        /// Get random bytes.
+        /// </summary>
+        /// <param name="output">The array of bytes to write the random bytes to.</param>
+        /// <returns>The byte array.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the random number generator has not been initialized</exception>
+        public static byte[] GetBytes(byte[] output)
+        {
+            if (Random == null)
+                throw new InvalidOperationException("You must initialize the random number generator before generating numbers.");
+            Random.GetBytes(output);
+            PushEntropy(output);
+            return output;
         }
 
         /// <summary>

--- a/src/Solnet.Wallet/Utilities/Utils.cs
+++ b/src/Solnet.Wallet/Utilities/Utils.cs
@@ -1,7 +1,7 @@
 using Chaos.NaCl;
+using Org.BouncyCastle.Crypto.Digests;
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 
 namespace Solnet.Wallet.Utilities
 {
@@ -78,7 +78,7 @@ namespace Solnet.Wallet.Utilities
         /// </summary>
         /// <param name="data">The data to hash.</param>
         /// <returns>The hash.</returns>
-        internal static byte[] Sha256(ReadOnlySpan<byte> data)
+        public static byte[] Sha256(ReadOnlySpan<byte> data)
         {
             return Sha256(data.ToArray(), 0, data.Length);
         }
@@ -92,11 +92,13 @@ namespace Solnet.Wallet.Utilities
         /// <returns>The hash.</returns>
         private static byte[] Sha256(byte[] data, int offset, int count)
         {
-            using SHA256Managed sha = new();
-            return sha.ComputeHash(data, offset, count);
+            byte[] i = new byte[32];
+            Sha256Digest digest = new ();
+            digest.BlockUpdate(data, offset, count);
+            digest.DoFinal(i, 0);
+            return i;
         }
-        
-        
+
         /// <summary>
         /// Gets the corresponding ed25519 key pair from the passed seed.
         /// </summary>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Refactor/Hotfix | No | Closes #101 |

## Problem

_What problem are you trying to solve?_

When trying to build an app using Blazor Wasm the wallet functionality would throw errors because of `System.Cryptography` not being available in the platform (browser)

## Solution

_How did you solve the problem?_

Migrated all usage to `BouncyCastle` which takes care of that.


**New dependencies**:

- `bouncycastle` : added to the wallet
