### PR TITLE
Fixed TransactionError parsing in log notifications

### DIFF
--- a/src/Solnet.Rpc/Models/Logs.cs
+++ b/src/Solnet.Rpc/Models/Logs.cs
@@ -14,7 +14,7 @@ namespace Solnet.Rpc.Models
         /// The error associated with the transaction simulation.
         /// </summary>
         [JsonPropertyName("err")]
-        public string Error { get; set; }
+        public TransactionError Error { get; set; }
 
         /// <summary>
         /// The log messages the transaction instructions output during execution.

--- a/test/Solnet.Rpc.Test/Resources/Streaming/Logs/LogsSubscribeNotificationWithError.json
+++ b/test/Solnet.Rpc.Test/Resources/Streaming/Logs/LogsSubscribeNotificationWithError.json
@@ -1,0 +1,20 @@
+{
+  "jsonrpc": "2.0",
+  "method": "logsNotification",
+  "params": {
+    "result": {
+      "context": { "slot": 84392429 },
+      "value": {
+        "err": {
+          "InstructionError": [
+            1,
+            { "Custom": 41 }
+          ]
+        },
+        "logs": [ "Program 9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin invoke [1]", "Program 9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin consumed 3769 of 200000 compute units", "Program 9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin success", "Program 9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin invoke [1]", "Program 9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin consumed 5619 of 200000 compute units", "Program 9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin failed: custom program error: 0x29" ],
+        "signature": "bGNVGCa1WFchzJStauKFVk7anzuFvA7hkMcx8Zi2o4euJaivzpwz8346yJ4Xn8H7XzMp44coTxdcDRd9d4yzj4m"
+      }
+    },
+    "subscription": 23784
+  }
+}

--- a/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
+++ b/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
@@ -231,6 +231,9 @@
     <None Update="Resources\Streaming\Logs\LogsSubscribeMentionConfirmed.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Streaming\Logs\LogsSubscribeNotificationWithError.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Streaming\Program\ProgramSubscribeConfirmed.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | Closes #122 |

## Problem

Issue parsing transaction errors in log notifications.


## Solution

Changed the type of the 'err' to the expected TransactionError.