### PR TITLE
Make JsonRpcBase an abstract base type

### DIFF
--- a/src/Solnet.Rpc/Messages/JsonRpcBase.cs
+++ b/src/Solnet.Rpc/Messages/JsonRpcBase.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Base JpnRpc message.
     /// </summary>
-    public class JsonRpcBase
+    public abstract class JsonRpcBase
     {
         /// <summary>
         /// The rpc version.


### PR DESCRIPTION
Since `JsonRpcBase` is intended to be a base class, make it impossible for the type to be instantiated anywhere else.
