### PR TITLE
Change PublicKeys constant length access modifier to be public (#145)

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>0.3.2</Version>
+    <Version>0.3.3</Version>
     <Copyright>Copyright 2021 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Wallet/PublicKey.cs
+++ b/src/Solnet.Wallet/PublicKey.cs
@@ -15,7 +15,7 @@ namespace Solnet.Wallet
         /// <summary>
         /// Public key length.
         /// </summary>
-        private const int PublicKeyLength = 32;
+        public const int PublicKeyLength = 32;
 
         private string _key;
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Refacto | No | Closes #145  |

## Problem

_What problem are you trying to solve?_

I'd like to have a public, hardcoded int of PublicKey length (always 32). It is currently marked as private. This will be used for Offset layout addition, instead of a local variable in each deserialization class, or 32 defined in an unnecessary, duplicate place.

## Solution

_How did you solve the problem?_

Switched access modifier for PublicKey.PublicKeyLength from private to public.
