### PR TITLE
Added GetConfirmedTransaction/Async methods as they are missing for m…

### DIFF
--- a/src/Solnet.Rpc/IRpcClient.cs
+++ b/src/Solnet.Rpc/IRpcClient.cs
@@ -796,7 +796,7 @@ namespace Solnet.Rpc
         /// <summary>
         /// Returns transaction details for a confirmed transaction.
         /// </summary>
-        /// <param name="signature">ransaction signature as base-58 encoded string.</param>
+        /// <param name="signature">Transaction signature as base-58 encoded string.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<TransactionMetaSlotInfo>> GetTransactionAsync(string signature,
@@ -806,15 +806,31 @@ namespace Solnet.Rpc
         /// Returns transaction details for a confirmed transaction.
         /// </summary>
         /// <param name="signature">Transaction signature as base-58 encoded string.</param>
+        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
+        Task<RequestResult<TransactionMetaSlotInfo>> GetConfirmedTransactionAsync(string signature);
+        
+        /// <summary>
+        /// Returns transaction details for a confirmed transaction.
+        /// </summary>
+        /// <param name="signature">Transaction signature as base-58 encoded string.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         RequestResult<TransactionMetaSlotInfo> GetTransaction(string signature, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
+        /// Returns transaction details for a confirmed transaction.
+        /// </summary>
+        /// <param name="signature">Transaction signature as base-58 encoded string.</param>
+        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
+        [Obsolete]
+        RequestResult<TransactionMetaSlotInfo> GetConfirmedTransaction(string signature);
+        
+        /// <summary>
         /// Gets the total transaction count of the ledger.
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
+        [Obsolete]
         Task<RequestResult<ulong>> GetTransactionCountAsync(Commitment commitment = Commitment.Finalized);
 
         /// <summary>

--- a/src/Solnet.Rpc/IRpcClient.cs
+++ b/src/Solnet.Rpc/IRpcClient.cs
@@ -830,7 +830,6 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
-        [Obsolete]
         Task<RequestResult<ulong>> GetTransactionCountAsync(Commitment commitment = Commitment.Finalized);
 
         /// <summary>

--- a/src/Solnet.Rpc/SolanaRpcClient.cs
+++ b/src/Solnet.Rpc/SolanaRpcClient.cs
@@ -295,10 +295,17 @@ namespace Solnet.Rpc
                 Parameters.Create(signature, ConfigObject.Create(KeyValue.Create("encoding","json"), HandleCommitment(commitment))));
         }
 
+        public async Task<RequestResult<TransactionMetaSlotInfo>> GetConfirmedTransactionAsync(string signature)
+        {
+            return await SendRequestAsync<TransactionMetaSlotInfo>("getConfirmedTransaction",
+                Parameters.Create(signature, ConfigObject.Create(KeyValue.Create("encoding","json"), HandleCommitment(Commitment.Confirmed))));
+        }
+
         /// <inheritdoc cref="IRpcClient.GetTransaction"/>
         public RequestResult<TransactionMetaSlotInfo> GetTransaction(string signature, Commitment commitment = Commitment.Finalized)
             => GetTransactionAsync(signature, commitment).Result;
 
+        public RequestResult<TransactionMetaSlotInfo> GetConfirmedTransaction(string signature) => GetConfirmedTransactionAsync(signature).Result;
 
         /// <inheritdoc cref="IRpcClient.GetBlockHeightAsync"/>
         public async Task<RequestResult<ulong>> GetBlockHeightAsync(Commitment commitment = Commitment.Finalized)

--- a/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetConfirmedTransactionRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetConfirmedTransactionRequest.json
@@ -1,0 +1,1 @@
+{"method":"getConfirmedTransaction","params":["5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1",{"encoding":"json","commitment":"confirmed"}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetConfirmedTransactionResponse.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetConfirmedTransactionResponse.json
@@ -1,0 +1,39 @@
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "blockTime": 1622655364,
+    "meta": {
+      "err": null,
+      "fee": 5000,
+      "innerInstructions": [],
+      "logMessages": [ "Program Vote111111111111111111111111111111111111111 invoke [1]", "Program Vote111111111111111111111111111111111111111 success" ],
+      "postBalances": [ 395383573380, 7282661174070, 1, 1, 1 ],
+      "postTokenBalances": [],
+      "preBalances": [ 395383578380, 7282661174070, 1, 1, 1 ],
+      "preTokenBalances": [],
+      "rewards": [],
+      "status": { "Ok": null }
+    },
+    "slot": 79700345,
+    "transaction": {
+      "message": {
+        "accountKeys": [ "EvVrzsxoj118sxxSTrcnc9u3fRdQfCc7d4gRzzX6TSqj", "6iuQJhi7Qqzg9LsyFBQpcS1uttP2sZ49pYMprL5GGy2Z", "SysvarS1otHashes111111111111111111111111111", "SysvarC1ock11111111111111111111111111111111", "Vote111111111111111111111111111111111111111" ],
+        "header": {
+          "numReadonlySignedAccounts": 0,
+          "numReadonlyUnsignedAccounts": 3,
+          "numRequiredSignatures": 1
+        },
+        "instructions": [
+          {
+            "accounts": [ 1, 2, 3, 0 ],
+            "data": "2kr3BYaDkghC7rvHsQYnBNoB4dhXrUmzgYMM4kbHSG7ALa3qsMPxfC9cJTFDKyJaC8VYSjrey9pvyRivtESUJrC3qzr89pvS2o6MQhyRVxmh3raQStxFFYwZ6WyKFNoQXvcchBwy8uQGfhhUqzuLNREwRmZ5U2VgTjFWX8Vikqya6iyzvALQNZEvqz7ZoGEyRtJ6AzNyWbkUyEo63rZ5w3wnxmhr3Uood",
+            "programIdIndex": 4
+          }
+        ],
+        "recentBlockhash": "6XGYfEJ5CGGBA5E8E7Gw4ToyDLDNNAyUCb7CJj1rLk21"
+      },
+      "signatures": [ "5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1" ]
+    }
+  },
+  "id": 0
+}

--- a/test/Solnet.Rpc.Test/SolanaRpcClientBlockTests.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientBlockTests.cs
@@ -271,9 +271,67 @@ namespace Solnet.Rpc.Test
         }
 
         [TestMethod]
+        public void TestGetConfirmedTransaction()
+        {
+            var responseData = File.ReadAllText("Resources/Http/Transaction/GetConfirmedTransactionResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Transaction/GetConfirmedTransactionRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri
+            };
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var res = sut.GetConfirmedTransaction("5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1");
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(res.Result);
+            Assert.AreEqual(79700345UL, res.Result.Slot);
+
+            Assert.AreEqual(1622655364, res.Result.BlockTime);
+
+            TransactionMetaInfo first = res.Result;
+
+            Assert.IsNull(first.Meta.Error);
+
+            Assert.AreEqual(5000UL, first.Meta.Fee);
+            Assert.AreEqual(0, first.Meta.InnerInstructions.Length);
+            Assert.AreEqual(2, first.Meta.LogMessages.Length);
+            Assert.AreEqual(5, first.Meta.PostBalances.Length);
+            Assert.AreEqual(395383573380UL, first.Meta.PostBalances[0]);
+            Assert.AreEqual(5, first.Meta.PreBalances.Length);
+            Assert.AreEqual(395383578380UL, first.Meta.PreBalances[0]);
+            Assert.AreEqual(0, first.Meta.PostTokenBalances.Length);
+            Assert.AreEqual(0, first.Meta.PreTokenBalances.Length);
+
+            Assert.AreEqual(1, first.Transaction.Signatures.Length);
+            Assert.AreEqual("5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1", first.Transaction.Signatures[0]);
+
+            Assert.AreEqual(5, first.Transaction.Message.AccountKeys.Length);
+            Assert.AreEqual("EvVrzsxoj118sxxSTrcnc9u3fRdQfCc7d4gRzzX6TSqj", first.Transaction.Message.AccountKeys[0]);
+
+            Assert.AreEqual(0, first.Transaction.Message.Header.NumReadonlySignedAccounts);
+            Assert.AreEqual(3, first.Transaction.Message.Header.NumReadonlyUnsignedAccounts);
+            Assert.AreEqual(1, first.Transaction.Message.Header.NumRequiredSignatures);
+
+            Assert.AreEqual(1, first.Transaction.Message.Instructions.Length);
+            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].Accounts.Length);
+            Assert.AreEqual("2kr3BYaDkghC7rvHsQYnBNoB4dhXrUmzgYMM4kbHSG7ALa3qsMPxfC9cJTFDKyJaC8VYSjrey9pvyRivtESUJrC3qzr89pvS2o6MQ"
+                + "hyRVxmh3raQStxFFYwZ6WyKFNoQXvcchBwy8uQGfhhUqzuLNREwRmZ5U2VgTjFWX8Vikqya6iyzvALQNZEvqz7ZoGEyRtJ6AzNyWbkUyEo63rZ5w3wnxmhr3Uood",
+                first.Transaction.Message.Instructions[0].Data);
+
+            Assert.AreEqual(4, first.Transaction.Message.Instructions[0].ProgramIdIndex);
+
+            Assert.AreEqual("6XGYfEJ5CGGBA5E8E7Gw4ToyDLDNNAyUCb7CJj1rLk21", first.Transaction.Message.RecentBlockhash);
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+        
+        [TestMethod]
         public void TestGetTransaction()
         {
-
             var responseData = File.ReadAllText("Resources/Http/Transaction/GetTransactionResponse.json");
             var requestData = File.ReadAllText("Resources/Http/Transaction/GetTransactionRequest.json");
             var sentMessage = string.Empty;

--- a/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
+++ b/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
@@ -594,6 +594,12 @@
     <None Update="Resources\Http\Accounts\GetProgramAccountsDataSizeRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Http\Transaction\GetConfirmedTransactionRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Http\Transaction\GetConfirmedTransactionResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
…ainnet beta usage

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | N/A |

## Problem

_What problem are you trying to solve?_

Mainnet-beta still runs solana-core v1.6 and the methods that got added on v1.7 to replace those that will be deprecated after v1.8 aren't available

## Solution

_How did you solve the problem?_

Implemented `GetConfirmedTransaction` as `Obsolete` to use it on mainnet because `GetTransaction` is only available on solana-core v1.7+
