### PR TITLE
Adds ATA example and fixes a bug in ATA program and PDAs.

### DIFF
--- a/src/Solnet.Examples/AssociatedTokenAccountsExample.cs
+++ b/src/Solnet.Examples/AssociatedTokenAccountsExample.cs
@@ -1,0 +1,157 @@
+using Solnet.Programs;
+using Solnet.Rpc;
+using Solnet.Rpc.Builders;
+using Solnet.Rpc.Core.Http;
+using Solnet.Rpc.Messages;
+using Solnet.Rpc.Models;
+using Solnet.Rpc.Types;
+using Solnet.Wallet;
+using System;
+using System.Threading;
+
+namespace Solnet.Examples
+{
+    public class AssociatedTokenAccountsExample : IExample
+    {
+        
+        private static readonly IRpcClient RpcClient = ClientFactory.GetClient(Cluster.TestNet);
+
+        private const string MnemonicWords =
+            "route clerk disease box emerge airport loud waste attitude film army tray " +
+            "forward deal onion eight catalog surface unit card window walnut wealth medal";
+
+        public void Run()
+        {
+            Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
+            
+            /*
+             * The following region creates and initializes a mint account, it also creates a token account
+             * that is initialized with the same mint account and then mints tokens to this newly created token account.
+             */
+            #region Create and Initialize a token Mint Account
+            
+            
+            RequestResult<ResponseValue<BlockHash>> blockHash = RpcClient.GetRecentBlockHash();
+            
+            ulong minBalanceForExemptionAcc =
+                RpcClient.GetMinimumBalanceForRentExemption(SystemProgram.AccountDataSize).Result;
+            ulong minBalanceForExemptionMint =
+                RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+            
+            Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
+            Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
+
+            Account ownerAccount = wallet.GetAccount(10);
+            Account mintAccount = wallet.GetAccount(1002);
+            Account initialAccount = wallet.GetAccount(1102);
+            Console.WriteLine($"OwnerAccount: {ownerAccount.PublicKey.Key}");
+            Console.WriteLine($"MintAccount: {mintAccount.PublicKey.Key}");
+            Console.WriteLine($"InitialAccount: {initialAccount.PublicKey.Key}");
+            
+            byte[] createAndInitializeMintToTx = new TransactionBuilder().
+                SetRecentBlockHash(blockHash.Result.Value.Blockhash).
+                SetFeePayer(ownerAccount).
+                AddInstruction(SystemProgram.CreateAccount(
+                    ownerAccount,
+                    mintAccount,
+                    minBalanceForExemptionMint,
+                    TokenProgram.MintAccountDataSize,
+                    TokenProgram.ProgramIdKey)).
+                AddInstruction(TokenProgram.InitializeMint(
+                    mintAccount.PublicKey,
+                    2,
+                    ownerAccount.PublicKey,
+                    ownerAccount.PublicKey)).
+                AddInstruction(SystemProgram.CreateAccount(
+                    ownerAccount,
+                    initialAccount,
+                    minBalanceForExemptionAcc,
+                    SystemProgram.AccountDataSize,
+                    TokenProgram.ProgramIdKey)).
+                AddInstruction(TokenProgram.InitializeAccount(
+                    initialAccount.PublicKey,
+                    mintAccount.PublicKey,
+                    ownerAccount.PublicKey)).
+                AddInstruction(TokenProgram.MintTo(
+                    mintAccount.PublicKey,
+                    initialAccount.PublicKey,
+                    1_000_000,
+                    ownerAccount)).
+                AddInstruction(MemoProgram.NewMemo(initialAccount, "Hello from Sol.Net")).Build();
+            
+            string createAndInitializeMintToTxSignature = SubmitTxAndLog(createAndInitializeMintToTx);
+
+            PollConfirmedTx(createAndInitializeMintToTxSignature);
+            
+            #endregion
+            
+            /*
+             * The following region creates an associated token account (ATA) for a random account and a certain token mint
+             * (in this case it's the previously created token mintAccount) and transfers tokens from the previously created
+             * token account to the newly created ATA.
+             */
+            #region Create Associated Token Account
+            
+            // this public key is from a random account created via www.sollet.io
+            // to test this locally I recommend creating a wallet on sollet and deriving this
+            PublicKey associatedTokenAccountOwner = new ("65EoWs57dkMEWbK4TJkPDM76rnbumq7r3fiZJnxggj2G");
+            PublicKey associatedTokenAccount =
+                AssociatedTokenAccountProgram.DeriveAssociatedTokenAccount(associatedTokenAccountOwner, mintAccount);
+            Console.WriteLine($"AssociatedTokenAccountOwner: {associatedTokenAccountOwner.Key}");
+            Console.WriteLine($"AssociatedTokenAccount: {associatedTokenAccount.Key}");
+            
+            byte[] createAssociatedTokenAccountTx = new TransactionBuilder().
+                SetRecentBlockHash(blockHash.Result.Value.Blockhash).
+                SetFeePayer(ownerAccount).
+                AddInstruction(AssociatedTokenAccountProgram.CreateAssociatedTokenAccount(
+                    ownerAccount,
+                    associatedTokenAccountOwner,
+                    mintAccount)).
+                AddInstruction(TokenProgram.Transfer(
+                    initialAccount,
+                    associatedTokenAccount,
+                    25000,
+                    ownerAccount)).// the ownerAccount was set as the mint authority
+                AddInstruction(MemoProgram.NewMemo(ownerAccount, "Hello from Sol.Net")).Build();
+            
+            string createAssociatedTokenAccountTxSignature = SubmitTxAndLog(createAssociatedTokenAccountTx);
+            
+            PollConfirmedTx(createAssociatedTokenAccountTxSignature);
+
+            #endregion
+        }
+
+        /// <summary>
+        /// Submits a transaction and logs the output from SimulateTransaction.
+        /// </summary>
+        /// <param name="tx">The transaction data ready to simulate or submit to the network.</param>
+        private static string SubmitTxAndLog(byte[] tx)
+        {
+            Console.WriteLine($"Tx Data: {Convert.ToBase64String(tx)}");
+
+            RequestResult<ResponseValue<SimulationLogs>> txSim = RpcClient.SimulateTransaction(tx);
+            string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
+            Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
+
+            RequestResult<string> txReq = RpcClient.SendTransaction(tx);
+            Console.WriteLine($"Tx Signature: {txReq.Result}");
+
+            return txReq.Result;
+        }
+
+        /// <summary>
+        /// Polls the rpc client until a transaction signature has been confirmed.
+        /// </summary>
+        /// <param name="signature">The first transaction signature.</param>
+        private static void PollConfirmedTx(string signature)
+        {
+            RequestResult<TransactionMetaSlotInfo> txMeta = RpcClient.GetTransaction(signature);
+            if (!txMeta.WasSuccessful)
+            {
+                Thread.Sleep(2500);
+                PollConfirmedTx(signature);
+            }
+            if (txMeta.Result != null) return;
+        }
+    }
+}

--- a/src/Solnet.Examples/AssociatedTokenAccountsExample.cs
+++ b/src/Solnet.Examples/AssociatedTokenAccountsExample.cs
@@ -34,7 +34,7 @@ namespace Solnet.Examples
             RequestResult<ResponseValue<BlockHash>> blockHash = RpcClient.GetRecentBlockHash();
             
             ulong minBalanceForExemptionAcc =
-                RpcClient.GetMinimumBalanceForRentExemption(SystemProgram.AccountDataSize).Result;
+                RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
             ulong minBalanceForExemptionMint =
                 RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
             
@@ -66,7 +66,7 @@ namespace Solnet.Examples
                     ownerAccount,
                     initialAccount,
                     minBalanceForExemptionAcc,
-                    SystemProgram.AccountDataSize,
+                    TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey)).
                 AddInstruction(TokenProgram.InitializeAccount(
                     initialAccount.PublicKey,

--- a/src/Solnet.Examples/TransactionBuilderExample.cs
+++ b/src/Solnet.Examples/TransactionBuilderExample.cs
@@ -68,7 +68,7 @@ namespace Solnet.Examples
 
             var blockHash = rpcClient.GetRecentBlockHash();
             var minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(SystemProgram.AccountDataSize).Result;
+                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
 
             var minBalanceForExemptionMint =
@@ -100,7 +100,7 @@ namespace Solnet.Examples
                     ownerAccount,
                     initialAccount,
                     minBalanceForExemptionAcc,
-                    SystemProgram.AccountDataSize,
+                    TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey)).
                 AddInstruction(TokenProgram.InitializeAccount(
                     initialAccount.PublicKey,
@@ -137,7 +137,7 @@ namespace Solnet.Examples
             var wallet = new Wallet.Wallet(MnemonicWords);
 
             var blockHash = rpcClient.GetRecentBlockHash();
-            var minBalanceForExemptionAcc = rpcClient.GetMinimumBalanceForRentExemption(SystemProgram.AccountDataSize).Result;
+            var minBalanceForExemptionAcc = rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
 
             var mintAccount = wallet.GetAccount(31);
@@ -156,7 +156,7 @@ namespace Solnet.Examples
                     ownerAccount,
                     newAccount,
                     minBalanceForExemptionAcc,
-                    SystemProgram.AccountDataSize,
+                    TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey)).
                 AddInstruction(TokenProgram.InitializeAccount(
                     newAccount.PublicKey,
@@ -194,7 +194,7 @@ namespace Solnet.Examples
 
             var blockHash = rpcClient.GetRecentBlockHash();
             var minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(SystemProgram.AccountDataSize).Result;
+                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
 
             var mintAccount = wallet.GetAccount(21);
@@ -214,7 +214,7 @@ namespace Solnet.Examples
                     ownerAccount,
                     newAccount,
                     minBalanceForExemptionAcc,
-                    SystemProgram.AccountDataSize,
+                    TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey)).AddInstruction(
                 TokenProgram.InitializeAccount(
                     newAccount.PublicKey,

--- a/src/Solnet.Programs/AssociatedTokenAccountProgram.cs
+++ b/src/Solnet.Programs/AssociatedTokenAccountProgram.cs
@@ -27,10 +27,12 @@ namespace Solnet.Programs
         /// <param name="payer">The account used to fund the associated token account.</param>
         /// <param name="owner">The public key of the owner account for the new associated token account.</param>
         /// <param name="mint">The public key of the mint for the new associated token account.</param>
-        /// <returns>The transaction instruction.</returns>
+        /// <returns>The transaction instruction, returns null whenever an associated token address could not be derived..</returns>
         public static TransactionInstruction CreateAssociatedTokenAccount(Account payer, PublicKey owner, PublicKey mint)
         {
             PublicKey associatedTokenAddress = DeriveAssociatedTokenAccount(owner, mint);
+
+            if (associatedTokenAddress == null) return null;
             
             List<AccountMeta> keys = new()
             {
@@ -47,7 +49,7 @@ namespace Solnet.Programs
             {
                 ProgramId = ProgramIdKey.KeyBytes,
                 Keys = keys,
-                Data = System.Array.Empty<byte>()
+                Data = Array.Empty<byte>()
             };
         }
 
@@ -56,13 +58,13 @@ namespace Solnet.Programs
         /// </summary>
         /// <param name="owner">The public key of the owner account for the new associated token account.</param>
         /// <param name="mint">The public key of the mint for the new associated token account.</param>
-        /// <returns>The public key of the associated token account.</returns>
+        /// <returns>The public key of the associated token account if it could be found, otherwise null.</returns>
         public static PublicKey DeriveAssociatedTokenAccount(PublicKey owner, PublicKey mint)
         {
-            (byte[] associatedTokenAddress, int nonce) = AddressExtensions.FindProgramAddress(
+            bool success = AddressExtensions.TryFindProgramAddress(
                 new List<byte[]> { owner.KeyBytes, TokenProgram.ProgramIdKey.KeyBytes, mint.KeyBytes },
-                ProgramIdKey.KeyBytes);
-            return new PublicKey(associatedTokenAddress);
+                ProgramIdKey.KeyBytes, out byte[] derivedAssociatedTokenAddress, out _);
+            return success ? new PublicKey(derivedAssociatedTokenAddress) : null;
         }
     }
 }

--- a/src/Solnet.Programs/NameServiceProgram.cs
+++ b/src/Solnet.Programs/NameServiceProgram.cs
@@ -75,7 +75,7 @@ namespace Solnet.Programs
         /// <param name="hashedName">The hash of the name with the name service hash prefix.</param>
         /// <param name="nameClass">The account of the name class.</param>
         /// <param name="parentName">The public key of the parent name.</param>
-        /// <returns>The program derived address for the name.</returns>
+        /// <returns>The program derived address for the name if it could be found, otherwise null.</returns>
         public static PublicKey DeriveNameAccountKey(ReadOnlySpan<byte> hashedName, PublicKey nameClass = null, PublicKey parentName = null)
         {
             byte[] nameClassKey = new byte[32];
@@ -84,16 +84,9 @@ namespace Solnet.Programs
             if (nameClass != null) nameClassKey = nameClass.KeyBytes;
             if (parentName != null) parentNameKeyBytes = parentName.KeyBytes;
 
-            try
-            {
-                (byte[] nameAccountPublicKey, _) = AddressExtensions.FindProgramAddress(
-                    new List<byte[]> {hashedName.ToArray(), nameClassKey, parentNameKeyBytes}, ProgramIdKey.KeyBytes);
-                return new PublicKey(nameAccountPublicKey);
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            bool success = AddressExtensions.TryFindProgramAddress(
+                new List<byte[]> {hashedName.ToArray(), nameClassKey, parentNameKeyBytes}, ProgramIdKey.KeyBytes, out byte[] nameAccountPublicKey, out _);
+            return success ? new PublicKey(nameAccountPublicKey) : null;
         }
 
 

--- a/src/Solnet.Programs/SystemProgram.cs
+++ b/src/Solnet.Programs/SystemProgram.cs
@@ -28,11 +28,6 @@ namespace Solnet.Programs
         public static readonly PublicKey SysVarRentKey = new ("SysvarRent111111111111111111111111111111111");
 
         /// <summary>
-        /// Account layout size.
-        /// </summary>
-        public const int AccountDataSize = 165;
-
-        /// <summary>
         /// Initialize a new transaction instruction which interacts with the System Program to create a new account.
         /// </summary>
         /// <param name="fromAccount">The account from which the lamports will be transferred.</param>

--- a/src/Solnet.Programs/TokenProgram.cs
+++ b/src/Solnet.Programs/TokenProgram.cs
@@ -23,6 +23,11 @@ namespace Solnet.Programs
         /// Mint account account layout size.
         /// </summary>
         public const int MintAccountDataSize = 82;
+        
+        /// <summary>
+        /// Account layout size.
+        /// </summary>
+        public const int TokenAccountDataSize = 165;
 
         /// <summary>
         /// Initializes an instruction to transfer tokens from one account to another either directly or via a delegate.

--- a/src/Solnet.Rpc/Models/AccountKeysList.cs
+++ b/src/Solnet.Rpc/Models/AccountKeysList.cs
@@ -48,10 +48,13 @@ namespace Solnet.Rpc.Models
             {
                 bool ok = _accounts.TryGetValue(accountMeta.PublicKey, out AccountMeta account);
                 if (!ok) throw new Exception("account meta already exists but could not overwrite");
-                if (accountMeta.Writable && !account.Writable)
+                if (!accountMeta.Writable || account.Writable)
                 {
-                    _accounts.Add(accountMeta.PublicKey, accountMeta);
+                    return;
                 }
+
+                _accounts.Remove(account.PublicKey);
+                _accounts.Add(accountMeta.PublicKey, accountMeta);
             }
             else
             {

--- a/src/Solnet.Rpc/Utilities/AddressExtensions.cs
+++ b/src/Solnet.Rpc/Utilities/AddressExtensions.cs
@@ -1,8 +1,11 @@
 using Org.BouncyCastle.Crypto.Digests;
+using Solnet.Wallet.Utilities;
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 
 namespace Solnet.Rpc.Utilities
@@ -64,7 +67,7 @@ namespace Solnet.Rpc.Utilities
             int nonce = 255;
             List<byte[]> buffer = seeds.ToList();
 
-            while (nonce-- != 0)
+            while (nonce != 0)
             {
                 byte[] address;
                 try
@@ -75,6 +78,7 @@ namespace Solnet.Rpc.Utilities
                 catch (Exception)
                 {
                     buffer.RemoveAt(buffer.Count - 1);
+                    nonce--;
                     continue;
                 }
 

--- a/test/Solnet.Programs.Test/SystemProgramTest.cs
+++ b/test/Solnet.Programs.Test/SystemProgramTest.cs
@@ -135,7 +135,7 @@ namespace Solnet.Programs.Test
                 ownerAccount,
                 mintAccount,
                 BalanceForRentExemption,
-                SystemProgram.AccountDataSize,
+                TokenProgram.TokenAccountDataSize,
                 TokenProgram.ProgramIdKey);
 
             Assert.AreEqual(2, txInstruction.Keys.Count);

--- a/test/Solnet.Rpc.Test/TransactionBuilderTest.cs
+++ b/test/Solnet.Rpc.Test/TransactionBuilderTest.cs
@@ -120,7 +120,7 @@ namespace Solnet.Rpc.Test
                     ownerAccount,
                     initialAccount,
                     minBalanceForAccount,
-                    SystemProgram.AccountDataSize,
+                    TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey))
                 .AddInstruction(
                     TokenProgram.InitializeAccount(

--- a/test/Solnet.Rpc.Test/UtilitiesTest.cs
+++ b/test/Solnet.Rpc.Test/UtilitiesTest.cs
@@ -16,49 +16,54 @@ namespace Solnet.Rpc.Test
         [ExpectedException(typeof(ArgumentException))]
         public void TestCreateProgramAddressException()
         {
-            _ = AddressExtensions.CreateProgramAddress(
+            _ = AddressExtensions.TryCreateProgramAddress(
                 new[] { Encoding.UTF8.GetBytes("SeedPubey1111111111111111111111111111111111") },
-                Encoding.UTF8.GetBytes(LoaderProgramId));
+                Encoding.UTF8.GetBytes(LoaderProgramId), out _);
         }
 
         [TestMethod]
         public void TestCreateProgramAddress()
         {
             var b58 = new Base58Encoder();
-            var programAddress = AddressExtensions.CreateProgramAddress(
+            var success = AddressExtensions.TryCreateProgramAddress(
                 new[] { b58.DecodeData("SeedPubey1111111111111111111111111111111111") },
-                b58.DecodeData(LoaderProgramId));
+                b58.DecodeData(LoaderProgramId), out byte[] pubKey);
 
+            Assert.IsTrue(success);
             CollectionAssert.AreEqual(
-                b58.DecodeData("GUs5qLUfsEHkcMB9T38vjr18ypEhRuNWiePW2LoK4E3K"), programAddress);
+                b58.DecodeData("GUs5qLUfsEHkcMB9T38vjr18ypEhRuNWiePW2LoK4E3K"), pubKey);
 
-            programAddress = AddressExtensions.CreateProgramAddress(
+            success = AddressExtensions.TryCreateProgramAddress(
                 new[] { Encoding.UTF8.GetBytes(""), new byte[] { 1 } },
-                b58.DecodeData(LoaderProgramId));
+                b58.DecodeData(LoaderProgramId), out pubKey);
 
+            Assert.IsTrue(success);
             CollectionAssert.AreEqual(
-                b58.DecodeData("3gF2KMe9KiC6FNVBmfg9i267aMPvK37FewCip4eGBFcT"), programAddress);
+                b58.DecodeData("3gF2KMe9KiC6FNVBmfg9i267aMPvK37FewCip4eGBFcT"), pubKey);
 
-            programAddress = AddressExtensions.CreateProgramAddress(
+            success = AddressExtensions.TryCreateProgramAddress(
                 new[] { Encoding.UTF8.GetBytes("☉") },
-                b58.DecodeData(LoaderProgramId));
+                b58.DecodeData(LoaderProgramId), out pubKey);
 
+            Assert.IsTrue(success);
             CollectionAssert.AreEqual(
-                b58.DecodeData("7ytmC1nT1xY4RfxCV2ZgyA7UakC93do5ZdyhdF3EtPj7"), programAddress);
+                b58.DecodeData("7ytmC1nT1xY4RfxCV2ZgyA7UakC93do5ZdyhdF3EtPj7"), pubKey);
         }
 
         [TestMethod]
         public void TestFindProgramAddress()
         {
-            var programAddress = AddressExtensions.FindProgramAddress(
+            var tryFindSuccess = AddressExtensions.TryFindProgramAddress(
                 new[] { Encoding.UTF8.GetBytes("") },
-                Encoding.UTF8.GetBytes(LoaderProgramId));
+                Encoding.UTF8.GetBytes(LoaderProgramId), out byte[] derivedAddress, out int derivationNonce);
+            Assert.IsTrue(tryFindSuccess);
 
+            var createProgSuccess = AddressExtensions.TryCreateProgramAddress(
+                new[] {Encoding.UTF8.GetBytes(""), new[] {(byte)derivationNonce}},
+                Encoding.UTF8.GetBytes(LoaderProgramId), out byte[] pubKey);
+            Assert.IsTrue(createProgSuccess);
             CollectionAssert.AreEqual(
-                programAddress.Address,
-                AddressExtensions.CreateProgramAddress(
-                    new[] { Encoding.UTF8.GetBytes(""), new[] { (byte)programAddress.Nonce } },
-                    Encoding.UTF8.GetBytes(LoaderProgramId)));
+                derivedAddress, pubKey);
         }
     }
 }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature/Tooling/Refactor/Hotfix | No | Closes #159 Closes #158 |

## Problem

_What problem are you trying to solve?_

There was no example of using ATAs to send tokens to
While implementing an example I found out that some things weren't optimal for the library usage, such as:
 - `AssociatedTokenAccountProgram`  didn't have a public method to derive the ATA address
 - The `CreateAssociatedTokenAccount` instruction had a bug in the ATA key being non-writable
 - There was also an obscure bug in the `FindProgramAddresss` function where the nonce would start at 254 instead of 255, making most transactions using PDAs broken 

## Solution

_How did you solve the problem?_

- Added an example that creates, initializes and mints tokens to an account, polls GetTransaction until it's Finalized and then sends another transaction with a `CreateAssociatedTokenAccount` instruction and a `TokenProgram.Transfer` (ATA throws errors when the TX where the mint account is created and initialized is not Finalized)
- Fixed the `CreateAssociatedTokenAccount` instruction bug where the ATA key was non-writable
- Fixed the  `FindProgramAddresss` bug so it properly starts at 255
- Also fixed an issue in the `AccountKeysList` so it doesn't bork when a key is already present but we're trying to add it again as being writable on the transaction.