### PR TITLE
Changed getProgramAccounts memcmp filter to be a list

### DIFF
--- a/src/Solnet.Rpc/IRpcClient.cs
+++ b/src/Solnet.Rpc/IRpcClient.cs
@@ -623,27 +623,27 @@ namespace Solnet.Rpc
 
         /// <summary>
         /// Returns all accounts owned by the provided program Pubkey.
+        /// <remarks>Accounts must meet all filter criteria to be included in the results.</remarks>
         /// </summary>
         /// <param name="pubKey">The program public key.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <param name="dataSize">The data size of the account.</param>
-        /// <param name="memOffset">The offset into program account to start comparison.</param>
-        /// <param name="memBytes">The data to match against the program data, as base-58 encoded string and limited to 129 bytes.</param>
+        /// <param name="dataSize">The data size of the account to compare against the program account data.</param>
+        /// <param name="memCmpList">The list of comparisons to match against the program account data.</param>
         /// <returns>A task which may return a request result holding the context and account info.</returns>
         Task<RequestResult<List<AccountKeyPair>>> GetProgramAccountsAsync(string pubKey, Commitment commitment = Commitment.Finalized,
-            int? dataSize = null, int? memOffset = null, string memBytes = null);
+            int? dataSize = null, IList<MemCmp> memCmpList = null);
 
         /// <summary>
         /// Returns all accounts owned by the provided program Pubkey.
+        /// <remarks>Accounts must meet all filter criteria to be included in the results.</remarks>
         /// </summary>
         /// <param name="pubKey">The program public key.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <param name="dataSize">The data size of the account.</param>
-        /// <param name="memOffset">The offset into program account to start comparison.</param>
-        /// <param name="memBytes">The data to match against the program data, as base-58 encoded string and limited to 129 bytes.</param>
+        /// <param name="dataSize">The data size of the account to compare against the program account data.</param>
+        /// <param name="memCmpList">The list of comparisons to match against the program account data.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         RequestResult<List<AccountKeyPair>> GetProgramAccounts(string pubKey, Commitment commitment = Commitment.Finalized,
-            int? dataSize = null, int? memOffset = null, string memBytes = null);
+            int? dataSize = null, IList<MemCmp> memCmpList = null);
 
         /// <summary>
         /// Gets a recent block hash.

--- a/src/Solnet.Rpc/Models/Filters.cs
+++ b/src/Solnet.Rpc/Models/Filters.cs
@@ -1,0 +1,20 @@
+// unset
+
+namespace Solnet.Rpc.Models
+{
+    /// <summary>
+    /// Represents the <c>memcmp</c> filter for the <see cref="IRpcClient.GetProgramAccounts()"/> method.
+    /// </summary>
+    public class MemCmp
+    {
+        /// <summary>
+        /// The offset into program account data at which to start the comparison.
+        /// </summary>
+        public int Offset { get; set; }
+        
+        /// <summary>
+        /// The data to match against the program data, as base-58 encoded string and limited to 129 bytes.
+        /// </summary>
+        public string Bytes { get; set; }
+    }
+}

--- a/src/Solnet.Rpc/Models/Filters.cs
+++ b/src/Solnet.Rpc/Models/Filters.cs
@@ -3,7 +3,7 @@
 namespace Solnet.Rpc.Models
 {
     /// <summary>
-    /// Represents the <c>memcmp</c> filter for the <see cref="IRpcClient.GetProgramAccounts()"/> method.
+    /// Represents the <c>memcmp</c> filter for the <see cref="IRpcClient.GetProgramAccounts"/> method.
     /// </summary>
     public class MemCmp
     {

--- a/test/Solnet.Rpc.Test/SolanaRpcClientAccountTests.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientAccountTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Solnet.Rpc.Models;
 using Solnet.Rpc.Types;
 using System;
 using System.Collections.Generic;
@@ -173,7 +174,8 @@ namespace Solnet.Rpc.Test
 
             var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
 
-            var result = sut.GetProgramAccounts("4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T", dataSize: 500, memOffset: 25, memBytes: "3Mc6vR");
+            var result = sut.GetProgramAccounts("4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T", dataSize: 500, 
+                memCmpList: new List<MemCmp>{ new() { Offset = 25, Bytes = "3Mc6vR" }});
             Assert.AreEqual(requestData, sentMessage);
             Assert.IsNotNull(result.Result);
             Assert.IsTrue(result.WasSuccessful);


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature/Refactor | Yes | Closes #166 |

## Problem

_What problem are you trying to solve?_

See #166

The `filters` are a list and can have several `memcmp` filters (comes in handy for Serum OOAs for example)

## Solution

_How did you solve the problem?_

Added a MemCmp model
Refactored the `getProgramAccounts` signature to take a `List<MemCmp>` instead of just a single offset and bytes.
