### PR TITLE
Add data dictionary to RequestResult and bump to v0.4.3

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>0.4.2</Version>
+    <Version>0.4.3</Version>
     <Copyright>Copyright 2021 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Rpc/Core/Http/JsonRpcClient.cs
+++ b/src/Solnet.Rpc/Core/Http/JsonRpcClient.cs
@@ -126,6 +126,7 @@ namespace Solnet.Rpc.Core.Http
                     {
                         result.Reason = errorRes.Error.Message;
                         result.ServerErrorCode = errorRes.Error.Code;
+                        result.ErrorData = errorRes.Error.Data;
                     }
                     else
                     {

--- a/src/Solnet.Rpc/Core/Http/RequestResult.cs
+++ b/src/Solnet.Rpc/Core/Http/RequestResult.cs
@@ -1,6 +1,6 @@
-﻿using System.Net;
+﻿using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
-using System.Text.Json.Serialization;
 
 namespace Solnet.Rpc.Core.Http
 {
@@ -44,6 +44,11 @@ namespace Solnet.Rpc.Core.Http
         /// Returns the error code if one was found in the error object when the server is unable to handle the request.
         /// </summary>
         public int ServerErrorCode { get; set; }
+        
+        /// <summary>
+        /// The error data, if applicable.
+        /// </summary>
+        public Dictionary<string, object> ErrorData { get; set; }
 
         /// <summary>
         /// Contains the JSON RPC request payload


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Refactor/Hotfix | Yes (Addition) | Closes #188 |

## Problem

_What problem are you trying to solve?_

See #188 

## Solution

_How did you solve the problem?_

The optional `data` that may come with a unhealthy result from the rpc wasn't being returned in the `RequestResult`


