### PR TITLE
Extract IRequestResult from RequestResult<T> for assignment compatibi…

### DIFF
--- a/src/Solnet.Rpc/Core/Http/IRequestResult.cs
+++ b/src/Solnet.Rpc/Core/Http/IRequestResult.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace Solnet.Rpc.Core.Http
+{
+    /// <summary>
+    /// Interface used to tepresent the result of a given request.
+    /// </summary>
+    public interface IRequestResult
+    {
+        /// <summary>
+        /// Returns <c>true</c> if the request was successfully handled and parsed.
+        /// </summary>
+        bool WasSuccessful { get; }
+
+        /// <summary>
+        /// Returns <c>true</c> if the HTTP request was successful (e.g. Code 200).
+        /// </summary>
+        bool WasHttpRequestSuccessful { get; set; }
+
+        /// <summary>
+        /// Returns <c>true</c> if the request was successfully handled by the server and no error parameters are found in the result.
+        /// </summary>
+        bool WasRequestSuccessfullyHandled { get; set; }
+
+        /// <summary>
+        /// Returns a string with the reason for the error if <see cref="WasSuccessful"/> is <c>false</c>.
+        /// </summary>
+        string Reason { get; set; }
+
+        /// <summary>
+        /// Returns the <see cref="HttpStatusCode"/> of the request.
+        /// </summary>
+        HttpStatusCode HttpStatusCode { get; set; }
+
+        /// <summary>
+        /// Returns the error code if one was found in the error object when the server is unable to handle the request.
+        /// </summary>
+        int ServerErrorCode { get; set; }
+
+        /// <summary>
+        /// The error data, if applicable.
+        /// </summary>
+        Dictionary<string, object> ErrorData { get; set; }
+
+        /// <summary>
+        /// Contains the JSON RPC request payload
+        /// </summary>
+        string RawRpcRequest { get; }
+
+        /// <summary>
+        /// Contains the JSON RPC response payload
+        /// </summary>
+        string RawRpcResponse { get; }
+
+    }
+
+}

--- a/src/Solnet.Rpc/Core/Http/RequestResult.cs
+++ b/src/Solnet.Rpc/Core/Http/RequestResult.cs
@@ -8,7 +8,7 @@ namespace Solnet.Rpc.Core.Http
     /// Represents the result of a given request.
     /// </summary>
     /// <typeparam name="T">The type of the result.</typeparam>
-    public class RequestResult<T>
+    public class RequestResult<T> : IRequestResult
     {
         /// <summary>
         /// Returns <c>true</c> if the request was successfully handled and parsed.


### PR DESCRIPTION
Implementation for issue #194 

Low impact refactor that extracts IRequestResult as a non-generic interface from RequestResult<T> to allow assignment compatibility between different flavours of `RequestResult<T>`.

This change enables common handling of RPC results like this:

```csharp
        internal TokenWalletException(string message, IRequestResult failedResult) : base(message)
        {
            RequestResult = failedResult;
        }
```

Please could this be merged in to 0.4.x as `TokenWallet` could benefit from this PR.
