### PR TITLE
Adding Memo Program V2 address and flag to check if it's v1 or v2

### DIFF
--- a/src/Solnet.Examples/HelloWorldExample.cs
+++ b/src/Solnet.Examples/HelloWorldExample.cs
@@ -40,7 +40,7 @@ namespace Solnet.Examples
 
                     Console.WriteLine($"Balance: {balance.Result.Value}");
 
-                    var memoInstruction = MemoProgram.NewMemo(wallet.Account, "Hello Solana World, using Solnet :)");
+                    var memoInstruction = MemoProgram.NewMemoV2("Hello Solana World, using Solnet :)");
 
                     var recentHash = rpcClient.GetRecentBlockHash();
 

--- a/src/Solnet.Programs/InstructionDecoder.cs
+++ b/src/Solnet.Programs/InstructionDecoder.cs
@@ -29,6 +29,7 @@ namespace Solnet.Programs
         static InstructionDecoder()
         {
             InstructionDictionary.Add(MemoProgram.ProgramIdKey, MemoProgram.Decode);
+            InstructionDictionary.Add(MemoProgram.ProgramIdKeyV2, MemoProgram.Decode);
             InstructionDictionary.Add(SystemProgram.ProgramIdKey, SystemProgram.Decode);
             InstructionDictionary.Add(TokenProgram.ProgramIdKey, TokenProgram.Decode);
             InstructionDictionary.Add(AssociatedTokenAccountProgram.ProgramIdKey, AssociatedTokenAccountProgram.Decode);

--- a/src/Solnet.Programs/MemoProgram.cs
+++ b/src/Solnet.Programs/MemoProgram.cs
@@ -3,6 +3,7 @@ using Solnet.Wallet;
 using Solnet.Wallet.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Solnet.Programs
@@ -19,6 +20,11 @@ namespace Solnet.Programs
         /// The public key of the Memo Program.
         /// </summary>
         public static readonly PublicKey ProgramIdKey = new("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo");
+
+        /// <summary>
+        /// The public key of the Memo Program V2.
+        /// </summary>
+        public static readonly PublicKey ProgramIdKeyV2 = new("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
 
         /// <summary>
         /// The program's name.
@@ -51,6 +57,28 @@ namespace Solnet.Programs
                 Data = memoBytes
             };
         }
+        
+        /// <summary>
+        /// Initialize a new transaction instruction which interacts with the Memo Program.
+        /// </summary>
+        /// <param name="account">The public key of the account associated with the memo.</param>
+        /// <param name="memo">The memo to be included in the transaction.</param>
+        /// <returns>The <see cref="TransactionInstruction"/> which includes the memo data.</returns>
+        public static TransactionInstruction NewMemoV2(string memo, PublicKey account = null)
+        {
+            List<AccountMeta> keys = new ();
+            if (account != null)
+                keys.Add(AccountMeta.ReadOnly(account, true));
+            
+            byte[] memoBytes = Encoding.UTF8.GetBytes(memo);
+
+            return new TransactionInstruction
+            {
+                ProgramId = ProgramIdKeyV2.KeyBytes,
+                Keys = keys,
+                Data = memoBytes
+            };
+        }
 
         /// <summary>
         /// Decodes an instruction created by the Memo Program.
@@ -63,7 +91,7 @@ namespace Solnet.Programs
         {
             DecodedInstruction decodedInstruction = new ()
             {
-                PublicKey = ProgramIdKey,
+                PublicKey = keys.Any(x => x.Key == ProgramIdKey.Key) ? ProgramIdKey : ProgramIdKeyV2,
                 InstructionName = InstructionName,
                 ProgramName = ProgramName,
                 InnerInstructions = new List<DecodedInstruction>(),


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | Closes #196  |

## Problem

_What problem are you trying to solve?_

See #196 

## Solution

_How did you solve the problem?_

Added the address for Memo Program V2 and a flag to check which address
Added `NewMemoV2` so as not to break the many tests and existing implementations of `NewMemo`, made it so that it's not required to pass a `PublicKey` for the message to be signed.

Tested [here](https://explorer.solana.com/tx/2uRBzW3EqJRA2ADWbKQPCp1yfKvQ8Bh74jqeuc6CRYyakF9xWxejMAeHBuGCWwF1rK4KVwERe6cq9R2nVPCvTWFG?cluster=testnet)
