### PR TITLE
Added null check on key constructors from string and bumped to v0.4.5

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>0.4.4</Version>
+    <Version>0.4.5</Version>
     <Copyright>Copyright 2021 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Wallet/PrivateKey.cs
+++ b/src/Solnet.Wallet/PrivateKey.cs
@@ -33,7 +33,7 @@ namespace Solnet.Wallet
                 }
                 return _key;
             }
-            set { _key = value; }
+            set => _key = value;
         }
 
 
@@ -52,7 +52,7 @@ namespace Solnet.Wallet
                 }
                 return _keyBytes;
             }
-            set { _keyBytes = value; }
+            set => _keyBytes = value;
         }
 
 
@@ -74,7 +74,7 @@ namespace Solnet.Wallet
         /// <param name="key">The public key as base58 encoded string.</param>
         public PrivateKey(string key)
         {
-            Key = key;
+            Key = key ?? throw new ArgumentNullException(nameof(key));
         }
 
         /// <summary>

--- a/src/Solnet.Wallet/PrivateKey.cs
+++ b/src/Solnet.Wallet/PrivateKey.cs
@@ -62,6 +62,8 @@ namespace Solnet.Wallet
         /// <param name="key">The public key as byte array.</param>
         public PrivateKey(byte[] key)
         {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
             if (key.Length != PrivateKeyLength)
                 throw new ArgumentException("invalid key length", nameof(key));
             KeyBytes = new byte[PrivateKeyLength];

--- a/src/Solnet.Wallet/PublicKey.cs
+++ b/src/Solnet.Wallet/PublicKey.cs
@@ -60,6 +60,8 @@ namespace Solnet.Wallet
         /// <param name="key">The public key as byte array.</param>
         public PublicKey(byte[] key)
         {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
             if (key.Length != PublicKeyLength)
                 throw new ArgumentException("invalid key length", nameof(key));
             KeyBytes = new byte[PublicKeyLength];

--- a/src/Solnet.Wallet/PublicKey.cs
+++ b/src/Solnet.Wallet/PublicKey.cs
@@ -31,7 +31,7 @@ namespace Solnet.Wallet
                 }
                 return _key;
             }
-            set { _key = value; }
+            set => _key = value;
         }
 
 
@@ -50,7 +50,7 @@ namespace Solnet.Wallet
                 }
                 return _keyBytes;
             }
-            set { _keyBytes = value; }
+            set => _keyBytes = value;
         }
 
 
@@ -72,7 +72,7 @@ namespace Solnet.Wallet
         /// <param name="key">The public key as base58 encoded string.</param>
         public PublicKey(string key)
         {
-            Key = key;
+            Key = key ?? throw new ArgumentNullException(nameof(key));
         }
 
         /// <summary>

--- a/test/Solnet.Wallet.Test/KeysTest.cs
+++ b/test/Solnet.Wallet.Test/KeysTest.cs
@@ -80,6 +80,14 @@ namespace Solnet.Wallet.Test
         
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
+        public void TestNullPrivateKeyBytes()
+        {
+            byte[] key = null;
+            _ = new PrivateKey(key);
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
         public void TestNullPrivateKeyString()
         {
             string key = null;
@@ -107,12 +115,19 @@ namespace Solnet.Wallet.Test
             _ = new PublicKey(InvalidPublicKeyBytes.AsSpan());
         }
         
-        
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void TestNullPublicKeyString()
         {
             string key = null;
+            _ = new PublicKey(key);
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void TestNullPublicKeyBytes()
+        {
+            byte[] key = null;
             _ = new PublicKey(key);
         }
 

--- a/test/Solnet.Wallet.Test/KeysTest.cs
+++ b/test/Solnet.Wallet.Test/KeysTest.cs
@@ -77,6 +77,14 @@ namespace Solnet.Wallet.Test
         {
             _ = new PrivateKey(InvalidPrivateKeyBytes.AsSpan());
         }
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void TestNullPrivateKeyString()
+        {
+            string key = null;
+            _ = new PrivateKey(key);
+        }
 
         [TestMethod]
         public void TestPublicKeySpan()
@@ -97,6 +105,15 @@ namespace Solnet.Wallet.Test
         public void TestInvalidPublicKeyBytes()
         {
             _ = new PublicKey(InvalidPublicKeyBytes.AsSpan());
+        }
+        
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void TestNullPublicKeyString()
+        {
+            string key = null;
+            _ = new PublicKey(key);
         }
 
         [TestMethod]


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | Yes | Closes #198 |

## Problem

_What problem are you trying to solve?_

See #198 

Due to lack of null-check on key constructors from a string it was possible to trigger a stack overflow

## Solution

_How did you solve the problem?_

Added a null check which throws `ArgumentNullException`
