### PR TITLE
HTTP 4xx RPC Responses

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>0.4.6</Version>
+    <Version>0.4.7</Version>
     <Copyright>Copyright 2021 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/test/Solnet.Rpc.Test/Resources/Http/GetProgramAccountsRequest-Fail-410.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/GetProgramAccountsRequest-Fail-410.json
@@ -1,0 +1,1 @@
+{"method":"getProgramAccounts","params":["9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",{"encoding":"base64","filters":[{"dataSize":3228},{"memcmp":{"offset":45,"bytes":"9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5"}}]}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/GetProgramAccountsResponse-Fail-410.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/GetProgramAccountsResponse-Fail-410.json
@@ -1,0 +1,1 @@
+{"jsonrpc":"2.0","error":{"code":410,"message":"The RPC call or parameters have been disabled."},"id": null}

--- a/test/Solnet.Rpc.Test/SolanaRpcClientTest.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientTest.cs
@@ -912,5 +912,77 @@ namespace Solnet.Rpc.Test
             FinishTest(messageHandlerMock, TestnetUri);
 
         }
+
+        /// <summary>
+        /// Backstory - public RPC nodes no longer support GetProgramAccount requests for the Serum program-id
+        /// These are dealt with a HTTP 410 "GONE" response.
+        /// Make sure that the JsonRpc gives an practical response under these circumstances.
+        /// </summary>
+        [TestMethod]
+        public void TestFailHttp410Gone()
+        {
+            var responseData = File.ReadAllText("Resources/Http/GetProgramAccountsResponse-Fail-410.json");
+            var requestData = File.ReadAllText("Resources/Http/GetProgramAccountsRequest-Fail-410.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData, HttpStatusCode.Gone);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            List<MemCmp> filters = new()
+            {
+                new MemCmp { Offset = 45, Bytes = "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5" },
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+            var result = sut.GetProgramAccounts("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin", // serum program-id
+                dataSize:3228, memCmpList:filters ); 
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(HttpStatusCode.Gone, result.HttpStatusCode);
+            Assert.AreEqual(responseData, result.RawRpcResponse);
+            Assert.IsFalse(result.WasSuccessful);
+            Assert.IsNull(result.Result);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+        /// <summary>
+        /// Backstory - when hopping from public RPC node to Serum RPC node there was a difference in their configuration
+        /// Solnet was sending Content-Type header of `application/json; charset=utf-8` which is rejected by Serum RPC cluster.
+        /// This was dealt with by a HTTP 415 response which was not accessible in the Solnet Result.
+        /// </summary>
+        [TestMethod]
+        public void TestFailHttp415UnsupportedMediaType()
+        {
+            var responseData = "Supplied content type is not allowed. Content-Type: application/json is required";
+            var requestData = File.ReadAllText("Resources/Http/GetBalanceRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData, HttpStatusCode.UnsupportedMediaType);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+            var result = sut.GetBalance("hoakwpFB8UoLnPpLC56gsjpY7XbVwaCuRQRMQzN5TVh");
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(HttpStatusCode.UnsupportedMediaType, result.HttpStatusCode);
+            Assert.AreEqual(responseData, result.RawRpcResponse);
+            Assert.IsFalse(result.WasSuccessful);
+            Assert.IsNull(result.Result);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
+
+
     }
 }

--- a/test/Solnet.Rpc.Test/SolanaRpcClientTestBase.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientTestBase.cs
@@ -32,11 +32,22 @@ namespace Solnet.Rpc.Test
         }
 
         /// <summary>
-        /// Setup the test with the request and response data.
+        /// Setup the test with the request and response data and a 200 OK.
         /// </summary>
         /// <param name="sentPayloadCapture">Capture the sent content.</param>
         /// <param name="responseContent">The response content.</param>
         protected Mock<HttpMessageHandler> SetupTest(Action<string> sentPayloadCapture, string responseContent)
+        {
+            return SetupTest(sentPayloadCapture, responseContent, HttpStatusCode.OK);
+        }
+
+        /// <summary>
+        /// Setup the test with the request and response data and the HTTP status code.
+        /// </summary>
+        /// <param name="sentPayloadCapture">Capture the sent content.</param>
+        /// <param name="responseContent">The response content.</param>
+        /// <param name="statusCode">The HTTP Status Code to return.</param>
+        protected Mock<HttpMessageHandler> SetupTest(Action<string> sentPayloadCapture, string responseContent, HttpStatusCode statusCode)
         {
             var messageHandlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             messageHandlerMock
@@ -52,7 +63,7 @@ namespace Solnet.Rpc.Test
                     sentPayloadCapture(httpRequest.Content.ReadAsStringAsync(ct).Result))
                 .ReturnsAsync(new HttpResponseMessage
                 {
-                    StatusCode = HttpStatusCode.OK,
+                    StatusCode = statusCode,
                     Content = new StringContent(responseContent),
                 })
                 .Verifiable();

--- a/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
+++ b/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
@@ -99,6 +99,12 @@
     <None Update="Resources\Http\Blocks\GetBlocksResponse.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Http\GetProgramAccountsResponse-Fail-410.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Http\GetProgramAccountsRequest-Fail-410.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Http\RequestAirdropRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | 
| :---: | :---: | :---: | 
| Ready| Bug/Hotfix | Yes | 

## Problem
Two separate problems solved by one fix.
The public Solana RPC nodes introduced a ban on getProgramAccount requests using the Serum Program ID.
The result was a HTTP 410 GONE JSON RPC response.
The fix to this was to use the Serum RPC cluster instead of the mainnet-beta cluster.
This triggered a second problem, the Serum RPC Cluster does not accept a charset inclusion in the Content-Type header.

Two things are addressed by the PR:
- When handling the 4xx family of errors, JSON RPC does not throw an exception and the RawRpcResponse was not being set,
- More importantly, the ability to interact with the Serum RPC Cluster

## Fundamentals
Mainnet-Beta RPC cluster ban hammer on getProgramAccounts for Serum:
```
curl https://api.mainnet-beta.solana.com/ -X POST -H "Content-Type: application/json; charset=utf-8" -d '
{"method":"getProgramAccounts","params":["9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",{"encoding":"base64","filters":[{"dataSize":3228},{"memcmp":{"offset":45,"bytes":"9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5"}}]}],"jsonrpc":"2.0","id":1}
'
=> 410 / {"jsonrpc":"2.0","error":{"code":410,"message":"The RPC call or parameters have been disabled."}, "id": null }
```
Serum RPC cluster not allowing charset directive in Content-Type header:
```
curl https://solana-api.projectserum.com/ -X POST -H "Content-Type: application/json; charset=utf-8" -d '

{"method":"getProgramAccounts","params":["9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",{"encoding":"base64","filters":[{"dataSize":3228},{"memcmp":{"offset":45,"bytes":"9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5"}}]}],"jsonrpc":"2.0","id":1}
'
=> 415 / Supplied content type is not allowed. Content-Type: application/json is required
```
Serum RPC cluster Content-Type satisfaction:
```
curl https://solana-api.projectserum.com/ -X POST -H "Content-Type: application/json" -d '
{"method":"getProgramAccounts","params":["9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",{"encoding":"base64","filters":[{"dataSize":3228},{"memcmp":{"offset":45,"bytes":"9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5"}}]}],"jsonrpc":"2.0","id":1}
'
=> 200 / ...data...
```

## Solution
Changed the construction of the HTTP request to make sure Content-Type header was just `application/json` and adjusted flow of code slightly to make sure RpcRawResponse gets set.

Added tests and refactored base test to allow injection of HTTP status codes other than 200/ok.

## Alternatives
The Serum RPC Cluster may well decide to support the charset directive in the content type header. Did not want to wait for that to happen so routed around this. Additional bandwidth of 'charset=...' per 1M HTTP requests is 14MB inbound.
