### PR TITLE
Add token list extended meta data fields to TokenDef

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>0.4.7</Version>
+    <Version>0.4.8</Version>
     <Copyright>Copyright 2021 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/Solnet.sln
+++ b/Solnet.sln
@@ -32,7 +32,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Solnet.KeyStore.Test", "tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Solnet.Programs.Test", "test\Solnet.Programs.Test\Solnet.Programs.Test.csproj", "{44B262CE-3AA3-43CE-B483-F49605E80E7B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Solnet.Extensions", "src\Solnet.Extensions\Solnet.Extensions.csproj", "{676C103F-927C-42A1-A5C3-16136E50E805}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Solnet.Extensions", "src\Solnet.Extensions\Solnet.Extensions.csproj", "{676C103F-927C-42A1-A5C3-16136E50E805}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Solnet.Extensions.Test", "test\Solnet.Extensions.Test\Solnet.Extensions.Test.csproj", "{2FCF8D66-C706-43EC-BC5F-1E2B08758185}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -80,6 +82,10 @@ Global
 		{676C103F-927C-42A1-A5C3-16136E50E805}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{676C103F-927C-42A1-A5C3-16136E50E805}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{676C103F-927C-42A1-A5C3-16136E50E805}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FCF8D66-C706-43EC-BC5F-1E2B08758185}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FCF8D66-C706-43EC-BC5F-1E2B08758185}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FCF8D66-C706-43EC-BC5F-1E2B08758185}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FCF8D66-C706-43EC-BC5F-1E2B08758185}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build.cake
+++ b/build.cake
@@ -7,7 +7,8 @@ var testProjectsRelativePaths = new string[]
     "./test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj",
     "./test/Solnet.Wallet.Test/Solnet.Wallet.Test.csproj",
     "./test/Solnet.KeyStore.Test/Solnet.KeyStore.Test.csproj",
-    "./test/Solnet.Programs.Test/Solnet.Programs.Test.csproj"
+    "./test/Solnet.Programs.Test/Solnet.Programs.Test.csproj",
+    "./test/Solnet.Extensions.Test/Solnet.Extensions.Test.csproj"
 };
 
 var target = Argument("target", "Pack");

--- a/src/Solnet.Extensions/Models/TokenMint/TokenDef.cs
+++ b/src/Solnet.Extensions/Models/TokenMint/TokenDef.cs
@@ -50,6 +50,21 @@ namespace Solnet.Extensions.TokenMint
         public int DecimalPlaces { get; init; }
 
         /// <summary>
+        /// The Coingecko identifier as supplied by the standard Solana token list or null
+        /// </summary>
+        public string CoinGeckoId { get; init; }
+
+        /// <summary>
+        /// The token project / more info url as supplied by the standard Solana token list or null
+        /// </summary>
+        public string TokenProjectUrl { get; init; }
+
+        /// <summary>
+        /// The token logo url as supplied by the standard Solana token list or null
+        /// </summary>
+        public string TokenLogoUrl { get; init; }
+
+        /// <summary>
         /// Create an instance of the TokenQuantity object with the raw token quanity value provided.
         /// </summary>
         /// <param name="valueDecimal">Value as decimal.</param>
@@ -128,6 +143,7 @@ namespace Solnet.Extensions.TokenMint
         public string Symbol { get; set; }
         public string Name { get; set; }
         public int Decimals { get; set; }
+        public string LogoUri { get; set; }
         public Dictionary<string, object> Extensions { get; set; }
     }
 

--- a/src/Solnet.Extensions/Models/TokenMint/TokenDef.cs
+++ b/src/Solnet.Extensions/Models/TokenMint/TokenDef.cs
@@ -72,7 +72,7 @@ namespace Solnet.Extensions.TokenMint
         /// <returns>A TokenQuantity instance.</returns>
         public TokenQuantity CreateQuantity(decimal valueDecimal, ulong valueRaw)
         {
-            return new TokenQuantity(TokenMint, Symbol, TokenName, DecimalPlaces, valueDecimal, valueRaw);
+            return new TokenQuantity(this, valueDecimal, valueRaw);
         }
 
         /// <summary>
@@ -123,6 +123,24 @@ namespace Solnet.Extensions.TokenMint
             for (int ix = 0; ix < DecimalPlaces; ix++) impliedAmount = decimal.Divide(impliedAmount, 10);
             return impliedAmount;
         }
+
+        /// <summary>
+        /// Creates a clone of this TokenDef instance setting the decimalPlaces.
+        /// Used to go from a TokenDef with unknown decimal places (-1) to known decimal places.
+        /// </summary>
+        /// <param name="decimalPlaces">Number of decimal places for this token.</param>
+        /// <returns>A new TokenDef instance.</returns>
+        internal TokenDef CloneWithKnownDecimals(int decimalPlaces)
+        {
+            if (decimalPlaces < 0) throw new ArgumentOutOfRangeException("Decimal places must be 0+");
+            return new TokenDef(this.TokenMint, this.TokenName, this.Symbol, decimalPlaces)
+            {
+                CoinGeckoId = this.CoinGeckoId,
+                TokenLogoUrl = this.TokenLogoUrl,
+                TokenProjectUrl = this.TokenProjectUrl
+            };
+        }
+
 
     }
 

--- a/src/Solnet.Extensions/Models/TokenWallet/TokenQuantity.cs
+++ b/src/Solnet.Extensions/Models/TokenWallet/TokenQuantity.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Solnet.Extensions.TokenMint;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,26 +16,26 @@ namespace Solnet.Extensions
         /// <summary>
         /// Constructs a TokenQuantity instance.
         /// </summary>
-        /// <param name="tokenMint">The token mint public key address.</param>
-        /// <param name="tokenSymbol">The symbol this token uses.</param>
-        /// <param name="tokenName">The name of this token.</param>
-        /// <param name="decimalPlaces">The number of decimal places this token uses.</param>
+        /// <param name="tokenDef">A TokenDef instance that describes this token.</param>
         /// <param name="balanceDecimal">Token balance in decimal.</param>
         /// <param name="balanceRaw">Token balance in raw ulong.</param>
-        internal TokenQuantity(string tokenMint,
-                               string tokenSymbol,
-                               string tokenName,
-                               int decimalPlaces,
+        internal TokenQuantity(TokenDef tokenDef,
                                decimal balanceDecimal,
                                ulong balanceRaw)
         {
-            TokenMint = tokenMint ?? throw new ArgumentNullException(nameof(tokenMint));
-            Symbol = tokenSymbol ?? throw new ArgumentNullException(nameof(tokenSymbol));
-            TokenName = tokenName ?? throw new ArgumentNullException(nameof(tokenName));
-            DecimalPlaces = decimalPlaces;
+            TokenDef = tokenDef ?? throw new ArgumentNullException(nameof(tokenDef));
+            Symbol = tokenDef.Symbol;
+            TokenName = tokenDef.TokenName;
+            TokenMint = tokenDef.TokenMint;
+            DecimalPlaces = tokenDef.DecimalPlaces;
             QuantityDecimal = balanceDecimal;
             QuantityRaw = balanceRaw;
         }
+
+        /// <summary>
+        /// The origin TokenDef instance
+        /// </summary>
+        public TokenDef TokenDef { get; init; }
 
         /// <summary>
         /// The token mint public key address.
@@ -88,8 +89,8 @@ namespace Solnet.Extensions
                                            ulong valueRaw)
         {
 
-            return new TokenQuantity(TokenMint, Symbol, TokenName,
-                DecimalPlaces, QuantityDecimal + valueDecimal,
+            return new TokenQuantity(this.TokenDef,
+                QuantityDecimal + valueDecimal,
                 QuantityRaw + valueRaw);
 
         }

--- a/src/Solnet.Extensions/Models/TokenWallet/TokenWalletAccount.cs
+++ b/src/Solnet.Extensions/Models/TokenWallet/TokenWalletAccount.cs
@@ -1,4 +1,5 @@
-﻿using Solnet.Wallet;
+﻿using Solnet.Extensions.TokenMint;
+using Solnet.Wallet;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,26 +31,20 @@ namespace Solnet.Extensions
         /// <summary>
         /// Construct an instance of the TokenWalletAccount.
         /// </summary>
-        /// <param name="tokenMint">The token mint public key address.</param>
-        /// <param name="tokenSymbol">The symbol this token uses.</param>
-        /// <param name="tokenName">The name of this token.</param>
-        /// <param name="decimalPlaces">The number of decimal places this token uses.</param>
+        /// <param name="tokenDef">A TokenDef instance that describes this token.</param>
         /// <param name="balanceDecimal">Token balance in decimal.</param>
         /// <param name="balanceRaw">Token balance in raw ulong.</param>
         /// <param name="lamportsRaw">How many lamports does this balance represent.</param>
         /// <param name="publicKey">The public key of the account.</param>
         /// <param name="owner">The owner public key of the account.</param>
         /// <param name="isAta">A flag to indicate whether this account is an Associated Token Account.</param>
-        internal TokenWalletAccount(string tokenMint,
-                                    string tokenSymbol,
-                                    string tokenName,
-                                    int decimalPlaces,
+        internal TokenWalletAccount(TokenDef tokenDef,
                                     decimal balanceDecimal,
                                     ulong balanceRaw,
                                     ulong lamportsRaw,
                                     string publicKey,
                                     string owner,
-                                    bool isAta) : base(tokenMint, tokenSymbol, tokenName, decimalPlaces, balanceDecimal, balanceRaw, lamportsRaw, 1)
+                                    bool isAta) : base(tokenDef, balanceDecimal, balanceRaw, lamportsRaw, 1)
         {
             PublicKey = publicKey ?? throw new ArgumentNullException(nameof(publicKey));
             Owner = owner ?? throw new ArgumentNullException(nameof(owner));

--- a/src/Solnet.Extensions/Models/TokenWallet/TokenWalletBalance.cs
+++ b/src/Solnet.Extensions/Models/TokenWallet/TokenWalletBalance.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Solnet.Extensions.TokenMint;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,25 +16,16 @@ namespace Solnet.Extensions
         /// <summary>
         /// Constructs a TokenWalletBalance instance.
         /// </summary>
-        /// <param name="tokenMint">The token mint public key address.</param>
-        /// <param name="tokenSymbol">The symbol this token uses.</param>
-        /// <param name="tokenName">The name of this token.</param>
-        /// <param name="decimalPlaces">The number of decimal places this token uses.</param>
+        /// <param name="tokenDef">A TokenDef instance that describes this token.</param>
         /// <param name="balanceDecimal">Token balance in decimal.</param>
         /// <param name="balanceRaw">Token balance in raw ulong.</param>
         /// <param name="lamportsRaw">How many lamports does this balance represent.</param>
         /// <param name="accountCount">The number of accounts this balance represents. Start with 1.</param>
-        internal TokenWalletBalance(string tokenMint,
-                                    string tokenSymbol,
-                                    string tokenName,
-                                    int decimalPlaces,
+        internal TokenWalletBalance(TokenDef tokenDef,
                                     decimal balanceDecimal,
                                     ulong balanceRaw,
                                     ulong lamportsRaw,
-                                    int accountCount) : base(tokenMint,
-                                                             tokenSymbol,
-                                                             tokenName,
-                                                             decimalPlaces,
+                                    int accountCount) : base(tokenDef,
                                                              balanceDecimal,
                                                              balanceRaw)
         {
@@ -77,8 +69,9 @@ namespace Solnet.Extensions
                                                int accountCount)
         {
 
-            return new TokenWalletBalance(TokenMint, Symbol, TokenName,
-                DecimalPlaces, QuantityDecimal + valueDecimal,
+            return new TokenWalletBalance(
+                this.TokenDef,
+                QuantityDecimal + valueDecimal,
                 QuantityRaw + valueRaw, Lamports + lamportsRaw,
                 AccountCount + accountCount);
 

--- a/src/Solnet.Extensions/TokenMintResolver.cs
+++ b/src/Solnet.Extensions/TokenMintResolver.cs
@@ -44,7 +44,7 @@ namespace Solnet.Extensions
         {
             foreach (var token in tokenList.tokens)
             {
-                Add(new TokenDef(token.Address, token.Name, token.Symbol, token.Decimals));
+                Add(token);
             }
         }
 
@@ -139,6 +139,37 @@ namespace Solnet.Extensions
         public void Add(TokenDef token)
         {
             if (token is null) throw new ArgumentNullException(nameof(token));
+            _tokens[token.TokenMint] = token;
+        }
+
+        /// <summary>
+        /// Construct a TokenDef instance populated with extension goodies from the Solana token list.
+        /// </summary>
+        /// <param name="tokenItem">A TokenListItem instance.</param>
+        internal void Add(TokenListItem tokenItem)
+        {
+            if (tokenItem is null) throw new ArgumentNullException(nameof(tokenItem));
+
+            // pick out the token logo or null
+            string logoUrl = tokenItem.LogoUri;
+
+            // pick out the coingecko identifier if available
+            string coingeckoId = null;
+            if (tokenItem.Extensions.ContainsKey("coingeckoId")) coingeckoId = ((JsonElement) tokenItem.Extensions["coingeckoId"]).GetString();
+
+            // pick out the project website if available
+            string projectUrl = null;
+            if (tokenItem.Extensions.ContainsKey("website")) projectUrl = ((JsonElement)tokenItem.Extensions["website"]).GetString();
+
+            // construct the TokenDef instance
+            var token = new TokenDef(tokenItem.Address, tokenItem.Name, tokenItem.Symbol, tokenItem.Decimals)
+            {
+                CoinGeckoId = coingeckoId,
+                TokenLogoUrl = logoUrl,
+                TokenProjectUrl = projectUrl
+            };
+
+            // stash it
             _tokens[token.TokenMint] = token;
         }
 

--- a/test/Solnet.Extensions.Test/TokenMintTest.cs
+++ b/test/Solnet.Extensions.Test/TokenMintTest.cs
@@ -117,7 +117,7 @@ namespace Solnet.Extensions.Test
             var json = File.ReadAllText("Resources/TokenMint/SimpleTokenList.json");
             var tokens = TokenMintResolver.ParseTokenList(json);
 
-            // lookup unknown mint - non-fatal - returns unknown mint
+            // lookup USDC using mint 
             var usdc = tokens.Resolve("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
             Assert.IsNotNull(usdc);
             Assert.AreEqual(6, usdc.DecimalPlaces);

--- a/test/Solnet.Extensions.Test/TokenMintTest.cs
+++ b/test/Solnet.Extensions.Test/TokenMintTest.cs
@@ -110,6 +110,24 @@ namespace Solnet.Extensions.Test
             Assert.AreEqual(6, cope.DecimalPlaces);
         }
 
+        [TestMethod]
+        public void TestExtendedTokenMeta() 
+        {
+            // load simple 
+            var json = File.ReadAllText("Resources/TokenMint/SimpleTokenList.json");
+            var tokens = TokenMintResolver.ParseTokenList(json);
+
+            // lookup unknown mint - non-fatal - returns unknown mint
+            var usdc = tokens.Resolve("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+            Assert.IsNotNull(usdc);
+            Assert.AreEqual(6, usdc.DecimalPlaces);
+            Assert.AreEqual("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", usdc.TokenMint);
+            Assert.AreEqual("usd-coin", usdc.CoinGeckoId);
+            Assert.AreEqual("https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png", usdc.TokenLogoUrl);
+            Assert.AreEqual("https://www.centre.io/", usdc.TokenProjectUrl);
+
+        }
+
 
     }
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | 
| :---: | :---: | :---: | 
| Ready| Feature | Yes (enhancement) | 

## Problem
Expose additional token meta data from the Solana standard token list.
Specifically: coingeckoId, token logo URL and token project/website URL.

## Solution
Additional properties on the TokenDef object and new internals for construction/populations.

## Usage
Nothing additional required to use, but additional properties are now available on `TokenDef`.
e.g.

```csharp
// load simple 
var json = File.ReadAllText("Resources/TokenMint/SimpleTokenList.json");
var tokens = TokenMintResolver.ParseTokenList(json);

// lookup USDC using mint 
var usdc = tokens.Resolve("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
Assert.IsNotNull(usdc);
Assert.AreEqual(6, usdc.DecimalPlaces);
Assert.AreEqual("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", usdc.TokenMint);
Assert.AreEqual("usd-coin", usdc.CoinGeckoId);
Assert.AreEqual("https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png", usdc.TokenLogoUrl);
Assert.AreEqual("https://www.centre.io/", usdc.TokenProjectUrl);
```
