### PR TITLE
Added a new Subscription method to allow parsed subscription to token…

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>0.4.8</Version>
+    <Version>0.4.9</Version>
     <Copyright>Copyright 2021 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Examples/HelloWorldExample.cs
+++ b/src/Solnet.Examples/HelloWorldExample.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Solnet.Examples
 {
-    class HelloWorldExample : IExample
+    public class HelloWorldExample : IExample
     {
         public void Run()
         {

--- a/src/Solnet.Rpc/Core/Sockets/SubscriptionChannel.cs
+++ b/src/Solnet.Rpc/Core/Sockets/SubscriptionChannel.cs
@@ -8,6 +8,10 @@
         /// <summary>
         /// Account subscription (<c>accountSubscribe</c>). 
         /// </summary>
+        TokenAccount,
+        /// <summary>
+        /// Account subscription (<c>accountSubscribe</c>). 
+        /// </summary>
         Account,
         /// <summary>
         /// Logs subscription (<c>logsSubscribe</c>). 

--- a/src/Solnet.Rpc/IStreamingRpcClient.cs
+++ b/src/Solnet.Rpc/IStreamingRpcClient.cs
@@ -58,6 +58,30 @@ namespace Solnet.Rpc
         SubscriptionState SubscribeAccountInfo(string pubkey, Action<SubscriptionState, ResponseValue<AccountInfo>> callback, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
+        /// Subscribes asynchronously to Token Account notifications. Note: Only works if the account is a Token Account.
+        /// </summary>
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
+        /// <param name="pubkey">The public key of the account.</param>
+        /// <param name="callback">The callback to handle data notifications.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task<SubscriptionState> SubscribeTokenAccountAsync(string pubkey, Action<SubscriptionState, ResponseValue<TokenAccountInfo>> callback, Commitment commitment = Commitment.Finalized);
+
+        /// <summary>
+        /// Subscribes  to Token Account notifications. Note: Only works if the account is a Token Account.
+        /// </summary>
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
+        /// <param name="pubkey">The public key of the account.</param>
+        /// <param name="callback">The callback to handle data notifications.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>Returns an object representing the state of the subscription.</returns>
+        SubscriptionState SubscribeTokenAccount(string pubkey, Action<SubscriptionState, ResponseValue<TokenAccountInfo>> callback, Commitment commitment = Commitment.Finalized);
+
+        /// <summary>
         /// Subscribes asynchronously to the logs notifications that mention a given public key.
         /// </summary>
         /// <remarks>

--- a/src/Solnet.Rpc/SolanaStreamingRpcClient.cs
+++ b/src/Solnet.Rpc/SolanaStreamingRpcClient.cs
@@ -314,18 +314,6 @@ namespace Solnet.Rpc
             sub.HandleData(result);
         }
 
-        /// <summary>
-        /// Notifies a given subscription of a new data payload.
-        /// </summary>
-        /// <param name="subscription">The subscription ID received.</param>
-        /// <param name="data">The parsed data payload to notify.</param>
-        private void NotifyData(int subscription, object data)
-        {
-            var sub = RetrieveSubscription(subscription);
-
-            sub.HandleData(data);
-        }
-
         #region AccountInfo
         /// <inheritdoc cref="IStreamingRpcClient.SubscribeAccountInfoAsync(string, Action{SubscriptionState, ResponseValue{AccountInfo}}, Commitment)"/>
         public async Task<SubscriptionState> SubscribeAccountInfoAsync(string pubkey, Action<SubscriptionState, ResponseValue<AccountInfo>> callback, Commitment commitment = Commitment.Finalized)

--- a/test/Solnet.Rpc.Test/Resources/Streaming/Account/TokenAccountSubscribe.json
+++ b/test/Solnet.Rpc.Test/Resources/Streaming/Account/TokenAccountSubscribe.json
@@ -1,9 +1,1 @@
-{
-  "method": "accountSubscribe",
-  "params": [
-    "8CFo8bL8mZQK8abbFyypFMwEDd8tVJjHTTojMLgQTUSZ",
-    { "encoding": "jsonParsed" }
-  ],
-  "jsonrpc": "2.0",
-  "id": 0
-}
+{"method":"accountSubscribe","params":["CM78CPUeXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNH12",{"encoding":"jsonParsed"}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Streaming/Account/TokenAccountSubscribe.json
+++ b/test/Solnet.Rpc.Test/Resources/Streaming/Account/TokenAccountSubscribe.json
@@ -1,0 +1,9 @@
+{
+  "method": "accountSubscribe",
+  "params": [
+    "8CFo8bL8mZQK8abbFyypFMwEDd8tVJjHTTojMLgQTUSZ",
+    { "encoding": "jsonParsed" }
+  ],
+  "jsonrpc": "2.0",
+  "id": 0
+}

--- a/test/Solnet.Rpc.Test/Resources/Streaming/Account/TokenAccountSubscribeNotification.json
+++ b/test/Solnet.Rpc.Test/Resources/Streaming/Account/TokenAccountSubscribeNotification.json
@@ -1,0 +1,35 @@
+{
+  "jsonrpc": "2.0",
+  "method": "accountNotification",
+  "params": {
+    "result": {
+      "context": { "slot": 99118135 },
+      "value": {
+        "lamports": 2039280,
+        "data": {
+          "program": "spl-token",
+          "parsed": {
+            "info": {
+              "isNative": false,
+              "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+              "owner": "F8Vyqk3unwxkXukZFQeYyGmFfTG3CAX4v24iyrjEYBJV",
+              "state": "initialized",
+              "tokenAmount": {
+                "amount": "9830001302037",
+                "decimals": 6,
+                "uiAmount": 9830001.302037,
+                "uiAmountString": "9830001.302037"
+              }
+            },
+            "type": "account"
+          },
+          "space": 165
+        },
+        "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        "executable": false,
+        "rentEpoch": 229
+      }
+    },
+    "subscription": 23784
+  }
+}

--- a/test/Solnet.Rpc.Test/SolanaStreamingClientTest.cs
+++ b/test/Solnet.Rpc.Test/SolanaStreamingClientTest.cs
@@ -125,6 +125,46 @@ namespace Solnet.Rpc.Test
         }
 
         [TestMethod]
+        public void SubscribeTokenAccountTest()
+        {
+            var expected = File.ReadAllText("Resources/Streaming/Account/TokenAccountSubscribe.json");
+            var subConfirmContent = File.ReadAllBytes("Resources/Streaming/SubscribeConfirm.json");
+            var notificationContents = File.ReadAllBytes("Resources/Streaming/Account/TokenAccountSubscribeNotification.json");
+            ResponseValue<TokenAccountInfo> resultNotification = null;
+            var result = new ReadOnlyMemory<byte>();
+
+            SetupAction(out Action<SubscriptionState, ResponseValue<TokenAccountInfo>> action,
+                (x) => resultNotification = x,
+                (x) => result = x,
+                subConfirmContent,
+                notificationContents);
+
+            var sut = new SolanaStreamingRpcClient("wss://api.mainnet-beta.solana.com/", null, _socketMock.Object);
+
+            const string pubKey = "CM78CPUeXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNH12";
+
+            sut.ConnectAsync().Wait();
+            _ = sut.SubscribeTokenAccount(pubKey, action);
+            _subConfirmEvent.Set();
+
+            _socketMock.Verify(s => s.SendAsync(It.IsAny<ReadOnlyMemory<byte>>(),
+                WebSocketMessageType.Text,
+                true,
+                It.IsAny<CancellationToken>()));
+            var res = Encoding.UTF8.GetString(result.Span);
+            Assert.AreEqual(expected, res);
+
+            Assert.IsTrue(_notificationEvent.WaitOne());
+            Assert.AreEqual(99118135UL, resultNotification.Context.Slot);
+            Assert.AreEqual("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", resultNotification.Value.Owner);
+            Assert.AreEqual("F8Vyqk3unwxkXukZFQeYyGmFfTG3CAX4v24iyrjEYBJV", resultNotification.Value.Data.Parsed.Info.Owner);
+            Assert.AreEqual(9830001302037UL, resultNotification.Value.Data.Parsed.Info.TokenAmount.Amount);
+            Assert.AreEqual("9830001.302037", resultNotification.Value.Data.Parsed.Info.TokenAmount.UiAmountString);
+            Assert.AreEqual(6, resultNotification.Value.Data.Parsed.Info.TokenAmount.Decimals);
+            Assert.AreEqual(2039280UL, resultNotification.Value.Lamports);
+        }
+
+        [TestMethod]
         public void SubscribeAccountInfoTestProcessed()
         {
             var expected = File.ReadAllText("Resources/Streaming/Account/AccountSubscribeProcessed.json");

--- a/test/Solnet.Rpc.Test/SolanaStreamingClientTest.cs
+++ b/test/Solnet.Rpc.Test/SolanaStreamingClientTest.cs
@@ -158,7 +158,7 @@ namespace Solnet.Rpc.Test
             Assert.AreEqual(99118135UL, resultNotification.Context.Slot);
             Assert.AreEqual("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", resultNotification.Value.Owner);
             Assert.AreEqual("F8Vyqk3unwxkXukZFQeYyGmFfTG3CAX4v24iyrjEYBJV", resultNotification.Value.Data.Parsed.Info.Owner);
-            Assert.AreEqual(9830001302037UL, resultNotification.Value.Data.Parsed.Info.TokenAmount.Amount);
+            Assert.AreEqual("9830001302037", resultNotification.Value.Data.Parsed.Info.TokenAmount.Amount);
             Assert.AreEqual("9830001.302037", resultNotification.Value.Data.Parsed.Info.TokenAmount.UiAmountString);
             Assert.AreEqual(6, resultNotification.Value.Data.Parsed.Info.TokenAmount.Decimals);
             Assert.AreEqual(2039280UL, resultNotification.Value.Lamports);

--- a/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
+++ b/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
@@ -228,6 +228,12 @@
     <None Update="Resources\Http\Transaction\SimulateTransactionExtraParamsRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Streaming\Account\TokenAccountSubscribe.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Streaming\Account\TokenAccountSubscribeNotification.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Streaming\Account\AccountSubscribeProcessed.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes | [Link](<Issue link here>) |

## Problem

Missing easy to use token account subscription.


## Solution

Added non standard method to subscribe to token accounts and automatically decode them into TokenAccountInfo classes.
