### PR TITLE
Adding Equals override to compare keys and accounts efficiently

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>0.4.9</Version>
+    <Version>0.4.10</Version>
     <Copyright>Copyright 2021 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Wallet/Account.cs
+++ b/src/Solnet.Wallet/Account.cs
@@ -78,6 +78,14 @@ namespace Solnet.Wallet
             return bytes;
         }
 
+        /// <inheritdoc cref="Equals(object)"/>
+        public override bool Equals(object obj)
+        {
+            if (obj is Account account) return account.PublicKey == this.PublicKey;
+
+            return false;
+        }
+
         /// <summary>
         /// Conversion between a <see cref="Account"/> object and the corresponding private key.
         /// </summary>

--- a/src/Solnet.Wallet/PrivateKey.cs
+++ b/src/Solnet.Wallet/PrivateKey.cs
@@ -106,7 +106,7 @@ namespace Solnet.Wallet
         /// <inheritdoc cref="Equals(object)"/>
         public override bool Equals(object obj)
         {
-            if (obj is PublicKey pk) return pk.Key == this.Key;
+            if (obj is PrivateKey pk) return pk.Key == this.Key;
 
             return false;
         }

--- a/src/Solnet.Wallet/PrivateKey.cs
+++ b/src/Solnet.Wallet/PrivateKey.cs
@@ -103,6 +103,14 @@ namespace Solnet.Wallet
             return signature;
         }
 
+        /// <inheritdoc cref="Equals(object)"/>
+        public override bool Equals(object obj)
+        {
+            if (obj is PublicKey pk) return pk.Key == this.Key;
+
+            return false;
+        }
+
         /// <summary>
         /// Conversion between a <see cref="PrivateKey"/> object and the corresponding base-58 encoded private key.
         /// </summary>

--- a/src/Solnet.Wallet/PublicKey.cs
+++ b/src/Solnet.Wallet/PublicKey.cs
@@ -100,6 +100,14 @@ namespace Solnet.Wallet
             return Ed25519.Verify(signature, message, KeyBytes);
         }
 
+        /// <inheritdoc cref="Equals(object)"/>
+        public override bool Equals(object obj)
+        {
+            if (obj is PublicKey pk) return pk.Key == this.Key;
+
+            return false;
+        }
+
         /// <summary>
         /// Conversion between a <see cref="PublicKey"/> object and the corresponding base-58 encoded public key.
         /// </summary>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Feature| No | Closes #217 |

## Problem

_What problem are you trying to solve?_

In order to compare `Account`, `PublicKey` and `PrivateKey` we must access the underlying `Key`

## Solution

_How did you solve the problem?_

Added an `Equals` override to compare the `Key` or `PublicKey` for `Account`s in order to facilitate this comparison
