### PR TITLE
Fixing mint to example and adding more context to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ for a list of other commonly needed programs see below:
 
 ## Examples
 
-The [Solnet.Examples](https://github.com/bmresearch/Solnet/tree/master/src/Solnet.Examples/) project contains some code examples, but essentially we're trying very hard to
-make it intuitive and easy to use the library.
+The [Solnet.Examples](https://github.com/bmresearch/Solnet/tree/master/src/Solnet.Examples/) project contains some code examples,
+essentially we're trying very hard to make it intuitive and easy to use the library.
+When trying to run these examples they might lead to errors in cases where they create new accounts, in these cases, the response from the RPC
+contains an and the transaction simulation logs which state that `account address is ... already in use`,
+all you need to do is increment the value that is used to derive that account from the seed being used, i.e `wallet.GetAccount(value+1)`.
 
 ### Wallets
 

--- a/src/Solnet.Examples/TransactionBuilderExample.cs
+++ b/src/Solnet.Examples/TransactionBuilderExample.cs
@@ -151,7 +151,7 @@ namespace Solnet.Examples
                     25000000,
                     ownerAccount.PublicKey))
                 .AddInstruction(MemoProgram.NewMemo(initialAccount.PublicKey, "Hello from Sol.Net"))
-                .Build(new List<Account> { ownerAccount });
+                .Build(new List<Account> { ownerAccount, initialAccount });
 
             Console.WriteLine($"Tx: {Convert.ToBase64String(tx)}");
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No | Closes #222 |

## Problem

_What problem are you trying to solve?_

SimpleMintTo example is failing because of a missing signer
Lack of context on what to do when accounts have already been created in the context of running the examples

## Solution

_How did you solve the problem?_

Added the `initialAccount` to the list of signers for SimpleMintTo
Added more context to readme