### PR TITLE
Added the possibility of creating a StreamingRpcClient with a user pr…

### DIFF
--- a/src/Solnet.Rpc/ClientFactory.cs
+++ b/src/Solnet.Rpc/ClientFactory.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using System.Net.Http;
+using System.Net.WebSockets;
 
 namespace Solnet.Rpc
 {
@@ -142,10 +143,11 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="url">The network cluster url.</param>
         /// <param name="logger">The logger.</param>
+        /// <param name="clientWebSocket">A ClientWebSocket instance. If null, a new instance will be created.</param>
         /// <returns>The streaming client.</returns>
-        public static IStreamingRpcClient GetStreamingClient(string url, ILogger logger = null)
+        public static IStreamingRpcClient GetStreamingClient(string url, ILogger logger = null, ClientWebSocket clientWebSocket = null)
         {
-            return new SolanaStreamingRpcClient(url, logger);
+            return new SolanaStreamingRpcClient(url, logger, null, clientWebSocket);
         }
     }
 }

--- a/src/Solnet.Rpc/Core/Sockets/StreamingRpcClient.cs
+++ b/src/Solnet.Rpc/Core/Sockets/StreamingRpcClient.cs
@@ -49,10 +49,11 @@ namespace Solnet.Rpc.Core.Sockets
         /// <param name="url">The url of the streaming RPC server.</param>
         /// <param name="logger">The possible logger instance.</param>
         /// <param name="socket">The possible websocket instance. A new instance will be created if null.</param>
-        protected StreamingRpcClient(string url, ILogger logger, IWebSocket socket = default)
+        /// <param name="clientWebSocket">The possible ClientWebSocket instance. A new instance will be created if null.</param>
+        protected StreamingRpcClient(string url, ILogger logger, IWebSocket socket = default, ClientWebSocket clientWebSocket = default)
         {
             NodeAddress = new Uri(url);
-            ClientSocket = socket ?? new WebSocketWrapper(new ClientWebSocket());
+            ClientSocket = socket ?? new WebSocketWrapper(clientWebSocket ?? new ClientWebSocket());
             _logger = logger;
             _sem = new SemaphoreSlim(1, 1);
             _connectionStats = new ConnectionStats();

--- a/src/Solnet.Rpc/SolanaStreamingRpcClient.cs
+++ b/src/Solnet.Rpc/SolanaStreamingRpcClient.cs
@@ -43,7 +43,8 @@ namespace Solnet.Rpc
         /// <param name="url">The url of the server to connect to.</param>
         /// <param name="logger">The possible ILogger instance.</param>
         /// <param name="websocket">The possible IWebSocket instance.</param>
-        internal SolanaStreamingRpcClient(string url, ILogger logger = null, IWebSocket websocket = default) : base(url, logger, websocket)
+        /// <param name="clientWebSocket">The possible ClientWebSocket instance.</param>
+        internal SolanaStreamingRpcClient(string url, ILogger logger = null, IWebSocket websocket = default, ClientWebSocket clientWebSocket = default) : base(url, logger, websocket, clientWebSocket)
         {
         }
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Feature | No | #239  |

## Problem

Unable to specify custom headers on Websocket connection.


## Solution

Exposed the ability for users to provide a specific ClientWebSocket instance, this way the user can inject any headers, or control proxy options.
