### PR TITLE
Fixing solana keystore

### DIFF
--- a/src/Solnet.KeyStore/SolanaKeyStore.cs
+++ b/src/Solnet.KeyStore/SolanaKeyStore.cs
@@ -37,7 +37,7 @@ namespace Solnet.KeyStore
         /// <param name="wallet">The wallet to save to the keystore.</param>
         public void SaveKeystore(string path, Wallet.Wallet wallet)
         {
-            File.WriteAllBytes(path, Encoding.ASCII.GetBytes(wallet.DeriveMnemonicSeed().ToStringByteArray()));
+            File.WriteAllBytes(path, Encoding.ASCII.GetBytes(wallet.Account.PrivateKey.KeyBytes.ToStringByteArray()));
         }
 
         /// <summary>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No | #252  |

## Problem

_What problem are you trying to solve?_

Solana keystore was not saving the private key byte array as intended

## Solution

_How did you solve the problem?_

Changed the byte array it saves to the actual private key and not the mnemonic seed
