### PR TITLE
Optimizes GetSpan and GetBytes due to memory allocation

### DIFF
--- a/src/Solnet.Programs/Utilities/Deserialization.cs
+++ b/src/Solnet.Programs/Utilities/Deserialization.cs
@@ -132,13 +132,11 @@ namespace Solnet.Programs.Utilities
         /// <param name="length">The desired length for the new span.</param>
         /// <returns>A <see cref="Span{T}"/> of bytes.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the offset is too big for the span.</exception>
-        public static Span<byte> GetSpan(this ReadOnlySpan<byte> data, int offset, int length)
+        public static ReadOnlySpan<byte> GetSpan(this ReadOnlySpan<byte> data, int offset, int length)
         {
             if (offset + length > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
-            byte[] buffer = new byte[length];
-            data.Slice(offset, length).CopyTo(buffer);
-            return buffer;
+            return data.Slice(offset, length);
         }
 
         /// <summary>
@@ -269,9 +267,7 @@ namespace Solnet.Programs.Utilities
         {
             if (offset + length > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
-            byte[] buffer = new byte[length];
-            data.Slice(offset, length).CopyTo(buffer);
-            return buffer;
+            return data.Slice(offset, length).ToArray();
         }
     }
 }

--- a/test/Solnet.Programs.Test/Utilities/DeserializationUtilitiesTest.cs
+++ b/test/Solnet.Programs.Test/Utilities/DeserializationUtilitiesTest.cs
@@ -180,14 +180,14 @@ namespace Solnet.Programs.Test.Utilities
         public void TestReadSpanException()
         {
             ReadOnlySpan<byte> readSpan = PublicKeyBytes.AsSpan();
-            Span<byte> span = readSpan.GetSpan(1, 32);
+            ReadOnlySpan<byte> span = readSpan.GetSpan(1, 32);
         }
 
         [TestMethod]
         public void TestReadSpan()
         {
             ReadOnlySpan<byte> readSpan = PublicKeyBytes.AsSpan();
-            Span<byte> span = readSpan.GetSpan(0, 32);
+            ReadOnlySpan<byte> span = readSpan.GetSpan(0, 32);
 
             CollectionAssert.AreEqual(PublicKeyBytes, span.ToArray());
         }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Refactor| No | Closes #261 |

## Problem

_What problem are you trying to solve?_

Memory allocation issues during deseralization using `GetSpan` and `GetBytes`

## Solution

_How did you solve the problem?_

Refactored `GetSpan` to not allocate buffers and just rely on slicing
Refactored `GetBytes` for the same reason and just use `.ToArray()`
