### PR TITLE
Deserialize TokenSwap State Account

### DIFF
--- a/src/Solnet.Programs/Abstract/BaseProgram.cs
+++ b/src/Solnet.Programs/Abstract/BaseProgram.cs
@@ -1,0 +1,39 @@
+﻿using Solnet.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Solnet.Programs.Abstract
+{
+    /// <summary>
+    /// A class to abstract some of the core program commonality
+    /// </summary>
+    public abstract class BaseProgram : Program
+    {
+        private PublicKey _programIdKey;
+        private string _programName;
+
+        /// <summary>
+        /// The public key of the program.
+        /// </summary>
+        public virtual PublicKey ProgramIdKey => _programIdKey;
+
+        /// <summary>
+        /// The program's name.
+        /// </summary>
+        public virtual string ProgramName => _programName;
+
+        /// <summary>
+        /// Creates an instance of the base program class with specified id and name
+        /// </summary>
+        /// <param name="programIdKey">The program key</param>
+        /// <param name="programName">The program name</param>
+        protected BaseProgram(PublicKey programIdKey, string programName)
+        {
+            _programIdKey = programIdKey;
+            _programName = programName;
+        }
+    }
+}

--- a/src/Solnet.Programs/Abstract/Program.cs
+++ b/src/Solnet.Programs/Abstract/Program.cs
@@ -1,0 +1,21 @@
+﻿using Solnet.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Solnet.Programs.Abstract
+{
+    public interface Program
+    {
+        /// <summary>
+        /// The program's key
+        /// </summary>
+        PublicKey ProgramIdKey { get; }
+        /// <summary>
+        /// The name of the program
+        /// </summary>
+        string ProgramName { get; }
+    }
+}

--- a/src/Solnet.Programs/TokenSwap/Models/Fees.cs
+++ b/src/Solnet.Programs/TokenSwap/Models/Fees.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using Solnet.Programs.Utilities;
 
 namespace Solnet.Programs.TokenSwap.Models
@@ -64,6 +65,23 @@ namespace Solnet.Programs.TokenSwap.Models
             ret.WriteU64(HostFeeNumerator, 48);
             ret.WriteU64(HostFeeDenomerator, 56);
             return new Span<byte>(ret);
+        }
+
+        public static Fees Deserialize(byte[] bytes)
+        {
+            var span = new Span<byte>(bytes);
+            var f = new Fees()
+            {
+                TradeFeeNumerator = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(0, 8)),
+                TradeFeeDenominator = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(8, 8)),
+                OwnerTradeFeeNumerator = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(16, 8)),
+                OwnerTradeFeeDenomerator = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(24, 8)),
+                OwnerWithrawFeeNumerator = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(32, 8)),
+                OwnerWithrawFeeDenomerator = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(40, 8)),
+                HostFeeNumerator = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(48, 8)),
+                HostFeeDenomerator = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(56, 8)),
+            };
+            return f;
         }
     }
 }

--- a/src/Solnet.Programs/TokenSwap/Models/SwapCurve.cs
+++ b/src/Solnet.Programs/TokenSwap/Models/SwapCurve.cs
@@ -1,5 +1,6 @@
 ﻿using Solnet.Programs.Utilities;
 using System;
+using System.Buffers.Binary;
 
 namespace Solnet.Programs.TokenSwap.Models
 {
@@ -8,6 +9,11 @@ namespace Solnet.Programs.TokenSwap.Models
     /// </summary>
     public class SwapCurve
     {
+        /// <summary>
+        /// The constant procuct curve
+        /// </summary>
+        public static SwapCurve ConstantProduct => new SwapCurve() { CurveType = CurveType.ConstantProduct, Calculator = new ConstantProductCurve() };
+
         /// <summary>
         /// The curve type.
         /// </summary>
@@ -35,9 +41,19 @@ namespace Solnet.Programs.TokenSwap.Models
             return new Span<byte>(ret);
         }
 
-        /// <summary>
-        /// The constant procuct curve
-        /// </summary>
-        public static SwapCurve ConstantProduct => new SwapCurve() { CurveType = CurveType.ConstantProduct, Calculator = new ConstantProductCurve() };
+        public static SwapCurve Deserialize(byte[] bytes)
+        {
+            var s = new SwapCurve()
+            {
+                CurveType = (CurveType)bytes[0],
+                //todo other curves
+                Calculator = new ConstantProductCurve()
+            };
+            if (s.CurveType != CurveType.ConstantProduct)
+            {
+                throw new NotSupportedException("Only constant product curves are supported by Solnet currently");
+            }
+            return s;
+        }
     }
 }

--- a/src/Solnet.Programs/TokenSwap/Models/TokenSwapAccount.cs
+++ b/src/Solnet.Programs/TokenSwap/Models/TokenSwapAccount.cs
@@ -1,0 +1,115 @@
+﻿using Solnet.Wallet;
+
+namespace Solnet.Programs.TokenSwap.Models
+{
+
+    /// <summary>
+    /// TokenSwap program state
+    /// </summary>
+    public class TokenSwapAccount 
+    {
+        /// <summary>
+        /// the size of this account in bytes
+        /// </summary>
+        public const int TOKEN_SWAP_DATA_LEN = 324;
+
+        /// <summary>
+        /// Versions of this state account
+        /// </summary>
+        public enum SwapVersion { SwapV1 = 1 }
+
+        /// <summary>
+        /// Version of this state account
+        /// </summary>
+        public SwapVersion Version;
+
+        /// <summary>
+        /// Initialized state
+        /// </summary>
+        public bool IsInitialized;
+
+        /// <summary>
+        /// Nonce used in program address.
+        /// The program address is created deterministically with the nonce,
+        /// swap program id, and swap account pubkey.  This program address has
+        /// authority over the swap's token A account, token B account, and pool
+        /// token mint.
+        /// </summary>
+        public byte Nonce;
+
+        /// <summary>
+        /// Program ID of the tokens being exchanged.
+        /// </summary>
+        public PublicKey TokenProgramId;
+
+        /// <summary>
+        /// Token A
+        /// </summary>
+        public PublicKey TokenAAccount;
+
+        /// <summary>
+        /// Token B
+        /// </summary>
+        public PublicKey TokenBAccount;
+
+        /// <summary>
+        /// Pool tokens are issued when A or B tokens are deposited.
+        /// Pool tokens can be withdrawn back to the original A or B token.
+        /// </summary>
+        public PublicKey PoolMint;
+
+        /// <summary>
+        /// Mint information for token A
+        /// </summary>
+        public PublicKey TokenAMint;
+
+        /// <summary>
+        /// Mint information for token B
+        /// </summary>
+        public PublicKey TokenBMint;
+
+        /// <summary>
+        /// Pool token account to receive trading and / or withdrawal fees
+        /// </summary>
+        public PublicKey PoolFeeAccount;
+
+        /// <summary>
+        /// All fee information
+        /// </summary>
+        public Fees Fees;
+
+        /// <summary>
+        /// Swap curve parameters, to be unpacked and used by the SwapCurve, which
+        /// calculates swaps, deposits, and withdrawals
+        /// </summary>
+        public SwapCurve SwapCurve;
+
+        /// <summary>
+        /// Deserilize a token swap from the bytes of an account
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static TokenSwapAccount Deserialize(byte[] data)
+        {
+            if (data.Length != TOKEN_SWAP_DATA_LEN)
+                return null;
+
+            var ret = new TokenSwapAccount()
+            {
+                Version = SwapVersion.SwapV1,
+                IsInitialized = data[1] == 1,
+                Nonce = data[2],
+                TokenProgramId = new PublicKey(data[3..35]),
+                TokenAAccount = new PublicKey(data[35..67]),
+                TokenBAccount = new PublicKey(data[67..99]),
+                PoolMint = new PublicKey(data[99..131]),
+                TokenAMint = new PublicKey(data[131..163]),
+                TokenBMint = new PublicKey(data[163..195]),
+                PoolFeeAccount = new PublicKey(data[195..227]),
+                Fees = Fees.Deserialize(data[227..291]),
+                SwapCurve = SwapCurve.Deserialize(data[291..]),
+            };
+            return ret;
+        }
+    }
+}

--- a/test/Solnet.Programs.Test/TokenSwapProgramTest.cs
+++ b/test/Solnet.Programs.Test/TokenSwapProgramTest.cs
@@ -130,7 +130,8 @@ namespace Solnet.Programs.Test
             var poolFee = wallet.GetAccount(6);
             var poolToken = wallet.GetAccount(7);
 
-            var txInstruction = new TokenSwapProgram(tokenSwapAccount).Initialize(
+            var txInstruction = new TokenSwapProgram().Initialize(
+                tokenSwapAccount,
                 tokenA.PublicKey,
                 tokenB.PublicKey,
                 poolMint.PublicKey,
@@ -170,7 +171,8 @@ namespace Solnet.Programs.Test
             var fee = wallet.GetAccount(7);
             var hostFee = wallet.GetAccount(7);
 
-            var txInstruction = new TokenSwapProgram(tokenSwapAccount).Swap(
+            var txInstruction = new TokenSwapProgram().Swap(
+                tokenSwapAccount,
                 userXfer.PublicKey,
                 source.PublicKey,
                 into.PublicKey,
@@ -202,7 +204,8 @@ namespace Solnet.Programs.Test
             var poolTokenMint = wallet.GetAccount(7);
             var poolAccount = wallet.GetAccount(7);
 
-            var txInstruction = new TokenSwapProgram(tokenSwapAccount).DepositAllTokenTypes(
+            var txInstruction = new TokenSwapProgram().DepositAllTokenTypes(
+                tokenSwapAccount,
                 userXfer.PublicKey,
                 authA.PublicKey,
                 authB.PublicKey,
@@ -235,7 +238,8 @@ namespace Solnet.Programs.Test
             var tokenBTo = wallet.GetAccount(7);
             var feeAccount = wallet.GetAccount(7);
 
-            var txInstruction = new TokenSwapProgram(tokenSwapAccount).WithdrawAllTokenTypes(
+            var txInstruction = new TokenSwapProgram().WithdrawAllTokenTypes(
+                tokenSwapAccount,
                 userXfer.PublicKey,
                 poolTokenMint.PublicKey,
                 sourcePoolAccount.PublicKey,
@@ -267,7 +271,8 @@ namespace Solnet.Programs.Test
             var poolMint = wallet.GetAccount(7);
             var pool = wallet.GetAccount(7);
 
-            var txInstruction = new TokenSwapProgram(tokenSwapAccount).DepositSingleTokenTypeExactAmountIn(
+            var txInstruction = new TokenSwapProgram().DepositSingleTokenTypeExactAmountIn(
+                tokenSwapAccount,
                 userXfer.PublicKey,
                 tokenSource.PublicKey,
                 tokenA.PublicKey,
@@ -297,7 +302,8 @@ namespace Solnet.Programs.Test
             var userToken = wallet.GetAccount(7);
             var feeAccount = wallet.GetAccount(7);
 
-            var txInstruction = new TokenSwapProgram(tokenSwapAccount).WithdrawSingleTokenTypeExactAmountOut(
+            var txInstruction = new TokenSwapProgram().WithdrawSingleTokenTypeExactAmountOut(
+                tokenSwapAccount,
                 userXfer.PublicKey,
                 poolMint.PublicKey,
                 sourcePool.PublicKey,


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Feature | No | _none_ |

## Problem

The `TokenSwap` state accounts are not able to be deserialized

## Solution

- Created `TokenSwapAccount` and a `Deserialize` method on it. 
- Created a base `Program` account with common program things (id and name for now).  

I realize that most programs are all static, but by making them objects it'd be possible to add other functionality in the future.  For instance, using a non-standard program id (mainnet vs testnet), and a common program registry that knows how to decode any account.  I have a working version of that in another branch. For now, prior to further discussion, just pushing like this to get the deserialize in there.
