### PR TITLE
Remove the default requestUri "/" used in the HttpRequestMessage

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>0.4.14</Version>
+    <Version>0.4.15</Version>
     <Copyright>Copyright 2021 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Rpc/Core/Http/JsonRpcClient.cs
+++ b/src/Solnet.Rpc/Core/Http/JsonRpcClient.cs
@@ -73,7 +73,7 @@ namespace Solnet.Rpc.Core.Http
                 // create byte buffer to avoid charset=utf-8 in content-type header
                 // as this is rejected by some RPC nodes
                 var buffer = Encoding.UTF8.GetBytes(requestJson);
-                using var httpReq = new HttpRequestMessage(HttpMethod.Post, "/")
+                using var httpReq = new HttpRequestMessage(HttpMethod.Post, (string)null)
                 {
                     Content = new ByteArrayContent(buffer)
                     {


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready/Hold | Bug| Yes | [[Link](https://github.com/bmresearch/Solnet/issues/270)] |

## Problem

The current implementation is not compatible with authentication Token in the URL

ex : https://my-node-on-solana/myToken/


## Solution

Remove the extra requestUri argurment passed in argument during the SendRequest<T> calls.

## Before & After Screenshots

Simple test before update 

<img width="1059" alt="Capture d’écran 2021-12-20 à 10 56 59" src="https://user-images.githubusercontent.com/1686551/146753917-3300c091-7e03-4df5-9146-8e0d006b64c1.png">

simple test after update

<img width="1074" alt="Capture d’écran 2021-12-20 à 11 01 21" src="https://user-images.githubusercontent.com/1686551/146753951-2364355b-1f2a-4b89-b5e7-80b8bd1f7adc.png">

