### PR TITLE
Fixing json parse error

### DIFF
--- a/src/Solnet.Rpc/Converters/TransactionErrorJsonConverter.cs
+++ b/src/Solnet.Rpc/Converters/TransactionErrorJsonConverter.cs
@@ -105,7 +105,7 @@ namespace Solnet.Rpc.Converters
 
             if (reader.TokenType == JsonTokenType.Number)
             {
-                err.InstructionError.CustomError = reader.GetInt32();
+                err.InstructionError.CustomError = reader.GetInt64();
                 reader.Read(); //number
                 reader.Read(); //endobj
                 reader.Read(); //endarray

--- a/src/Solnet.Rpc/Converters/TransactionErrorJsonConverter.cs
+++ b/src/Solnet.Rpc/Converters/TransactionErrorJsonConverter.cs
@@ -105,7 +105,7 @@ namespace Solnet.Rpc.Converters
 
             if (reader.TokenType == JsonTokenType.Number)
             {
-                err.InstructionError.CustomError = reader.GetInt64();
+                err.InstructionError.CustomError = reader.GetUInt32();
                 reader.Read(); //number
                 reader.Read(); //endobj
                 reader.Read(); //endarray

--- a/src/Solnet.Rpc/Models/InstructionError.cs
+++ b/src/Solnet.Rpc/Models/InstructionError.cs
@@ -18,7 +18,7 @@
         /// <summary>
         /// Possible custom error id from a program.
         /// </summary>
-        public int? CustomError { get; set; }
+        public long? CustomError { get; set; }
 
         /// <summary>
         /// Possible string from borsh error.

--- a/src/Solnet.Rpc/Models/InstructionError.cs
+++ b/src/Solnet.Rpc/Models/InstructionError.cs
@@ -18,7 +18,7 @@
         /// <summary>
         /// Possible custom error id from a program.
         /// </summary>
-        public long? CustomError { get; set; }
+        public uint? CustomError { get; set; }
 
         /// <summary>
         /// Possible string from borsh error.

--- a/test/Solnet.Rpc.Test/SolanaRpcClientBlockTests.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientBlockTests.cs
@@ -56,7 +56,7 @@ namespace Solnet.Rpc.Test
             Assert.AreEqual(TransactionErrorType.InstructionError, first.Meta.Error.Type);
             Assert.IsNotNull(first.Meta.Error.InstructionError);
             Assert.AreEqual(InstructionErrorType.Custom, first.Meta.Error.InstructionError.Type);
-            Assert.AreEqual(0, first.Meta.Error.InstructionError.CustomError);
+            Assert.AreEqual(0u, first.Meta.Error.InstructionError.CustomError);
 
             Assert.AreEqual(5000UL, first.Meta.Fee);
             Assert.AreEqual(0, first.Meta.InnerInstructions.Length);
@@ -128,7 +128,7 @@ namespace Solnet.Rpc.Test
             Assert.AreEqual(TransactionErrorType.InstructionError, first.Meta.Error.Type);
             Assert.IsNotNull(first.Meta.Error.InstructionError);
             Assert.AreEqual(InstructionErrorType.Custom, first.Meta.Error.InstructionError.Type);
-            Assert.AreEqual(0, first.Meta.Error.InstructionError.CustomError);
+            Assert.AreEqual(0u, first.Meta.Error.InstructionError.CustomError);
 
             Assert.AreEqual(5000UL, first.Meta.Fee);
             Assert.AreEqual(0, first.Meta.InnerInstructions.Length);

--- a/test/Solnet.Rpc.Test/SolanaRpcClientTransactionsTest.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientTransactionsTest.cs
@@ -280,7 +280,7 @@ namespace Solnet.Rpc.Test
             Assert.AreEqual(TransactionErrorType.InstructionError, result.Result.Value.Error.Type);
             Assert.IsNotNull(result.Result.Value.Error.InstructionError);
             Assert.AreEqual(InstructionErrorType.Custom, result.Result.Value.Error.InstructionError.Type);
-            Assert.AreEqual(1, result.Result.Value.Error.InstructionError.CustomError);
+            Assert.AreEqual(1u, result.Result.Value.Error.InstructionError.CustomError);
             FinishTest(messageHandlerMock, TestnetUri);
         }
     }

--- a/test/Solnet.Rpc.Test/SolanaStreamingClientTest.cs
+++ b/test/Solnet.Rpc.Test/SolanaStreamingClientTest.cs
@@ -400,7 +400,7 @@ namespace Solnet.Rpc.Test
             Assert.IsTrue(_notificationEvent.WaitOne());
             Assert.AreEqual(TransactionErrorType.InstructionError, resultNotification.Value.Error.Type);
             Assert.AreEqual(InstructionErrorType.Custom, resultNotification.Value.Error.InstructionError.Type);
-            Assert.AreEqual(41, resultNotification.Value.Error.InstructionError.CustomError);
+            Assert.AreEqual(41u, resultNotification.Value.Error.InstructionError.CustomError);
 
             Assert.AreEqual("bGNVGCa1WFchzJStauKFVk7anzuFvA7hkMcx8Zi2o4euJaivzpwz8346yJ4Xn8H7XzMp44coTxdcDRd9d4yzj4m", resultNotification.Value.Signature);
         }
@@ -636,7 +636,7 @@ namespace Solnet.Rpc.Test
 
             Assert.AreEqual(TransactionErrorType.InstructionError, resultNotification.Value.Error.Type);
             Assert.AreEqual(InstructionErrorType.Custom, resultNotification.Value.Error.InstructionError.Type);
-            Assert.AreEqual(0, resultNotification.Value.Error.InstructionError.CustomError);
+            Assert.AreEqual(0u, resultNotification.Value.Error.InstructionError.CustomError);
 
             Assert.AreEqual(SubscriptionStatus.Unsubscribed, evt.Status);
             Assert.AreEqual(SubscriptionStatus.Unsubscribed, sub.State);


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | - |

## Problem

It throws a "JsonException" because it can not parse the json when the CustomError value is more than the maximum value of int.

It is possible to see this situation in dozens of slot, but you can see it in slot number 113766234 as an example.

![image](https://user-images.githubusercontent.com/7953033/147813397-529be279-ac4d-4d59-848c-ddf8b5b1c5ff.png)

## Solution

Changed CustomError's type from int to long.

