### PR TITLE
switch to System.Runtime.CompilerServices.Unsafe.CopyBlock for perfor…

### DIFF
--- a/src/Solnet.KeyStore/Crypto/Scrypt.cs
+++ b/src/Solnet.KeyStore/Crypto/Scrypt.cs
@@ -46,35 +46,7 @@ namespace Solnet.KeyStore.Crypto
         /// </summary>
         private static unsafe void BulkCopy(void* dst, void* src, int len)
         {
-            var d = (byte*)dst;
-            var s = (byte*)src;
-
-            while (len >= 8)
-            {
-                *(ulong*)d = *(ulong*)s;
-                d += 8;
-                s += 8;
-                len -= 8;
-            }
-            if (len >= 4)
-            {
-                *(uint*)d = *(uint*)s;
-                d += 4;
-
-                s += 4;
-                len -= 4;
-            }
-            if (len >= 2)
-            {
-                *(ushort*)d = *(ushort*)s;
-                d += 2;
-                s += 2;
-                len -= 2;
-            }
-            if (len >= 1)
-            {
-                *d = *s;
-            }
+            System.Runtime.CompilerServices.Unsafe.CopyBlock(dst, src,(uint) len);
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

Custom function to copy  two `void*` pointers is slower than `System.Runtime.CompilerServices.Unsafe.CopyBlock`

## Solution

Use  `System.Runtime.CompilerServices.Unsafe.CopyBlock` to do block copy to improve performance

## Benchmark_Results

```

BenchmarkDotNet=v0.13.1, OS=pop 21.10
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.101
  [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
  DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT


|                                       Method |  count |         Mean |     Error |    StdDev |
|--------------------------------------------- |------- |-------------:|----------:|----------:|
| SystemRuntimeCompilerServicesUnsafeCopyBlock |    100 |     10.84 ns |  0.058 ns |  0.054 ns |
|                                       Custom |    100 |     11.22 ns |  0.052 ns |  0.046 ns |
| SystemRuntimeCompilerServicesUnsafeCopyBlock |   1000 |     70.42 ns |  0.609 ns |  0.570 ns |
|                                       Custom |   1000 |    105.22 ns |  0.316 ns |  0.296 ns |
| SystemRuntimeCompilerServicesUnsafeCopyBlock |  10000 |    667.74 ns |  1.617 ns |  1.512 ns |
|                                       Custom |  10000 |  1,029.57 ns |  3.372 ns |  3.154 ns |
| SystemRuntimeCompilerServicesUnsafeCopyBlock | 100000 |  8,484.87 ns | 21.694 ns | 19.231 ns |
|                                       Custom | 100000 | 10,963.55 ns | 32.791 ns | 30.673 ns |

```

## Benchmark_SourceCode

```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

namespace PointerCopy;

public class Program
{
    [Params(100,1000,10000,100000)]
    public int count = 0;
    

    [Benchmark]

    public unsafe void   SystemRuntimeCompilerServicesUnsafeCopyBlock()
    {
        var s1 = stackalloc byte[count] ;
        var s2 = stackalloc byte[count] ;
        var _tmp = count;
        System.Runtime.CompilerServices.Unsafe.CopyBlock(s1, s2,(uint) _tmp);
    }

    [Benchmark]
    public unsafe void Custom()
    {
        var s1 = stackalloc byte[count] ;
        var s2 = stackalloc byte[count] ;
        BulkCopy(s1, s2, count);
    }
    
    private static unsafe void BulkCopy(void* dst, void* src, int len)
    {
    var d = (byte*) dst;
    var s = (byte*) src;

    while (len >= 8)
    {
        *(ulong*) d = *(ulong*) s;
        d += 8;
        s += 8;
        len -= 8;
    }

    if (len >= 4)
    {
        *(uint*) d = *(uint*) s;
        d += 4;

        s += 4;
        len -= 4;
    }

    if (len >= 2)
    {
        *(ushort*) d = *(ushort*) s;
        d += 2;
        s += 2;
        len -= 2;
    }

    if (len >= 1) *d = *s;
}

public static unsafe  void Main()
{
    var s1 = stackalloc byte[5] {0, 0, 0, 0, 0};
    var s2 = stackalloc byte[5] {1, 1, 1, 1, 1};
    System.Runtime.CompilerServices.Unsafe.CopyBlock(s1, s2, 5);
    for (var i = 0; i < 5; i++)
    {
        if (s1[i] != 1) throw new Exception("function did not worked as expected");
    }
    var summary = BenchmarkRunner.Run<Program>();
}

}


```