### PR TITLE
added PublicKey overload to GetBalance()

### DIFF
--- a/src/Solnet.Rpc/IRpcClient.cs
+++ b/src/Solnet.Rpc/IRpcClient.cs
@@ -2,6 +2,7 @@ using Solnet.Rpc.Core.Http;
 using Solnet.Rpc.Messages;
 using Solnet.Rpc.Models;
 using Solnet.Rpc.Types;
+using Solnet.Wallet;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -102,6 +103,17 @@ namespace Solnet.Rpc
         Task<RequestResult<ResponseValue<ulong>>> GetBalanceAsync(string pubKey, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
+        /// Gets the balance <b>asynchronously</b> for a certain public key.
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
+        /// </summary>
+        /// <param name="pubKey">The public key.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>A task which may return a request result holding the context and address balance.</returns>
+        Task<RequestResult<ResponseValue<ulong>>> GetBalanceAsync(PublicKey pubKey, Commitment commitment = Commitment.Finalized);
+        
+        /// <summary>
         /// Gets the balance <b>synchronously</b> for a certain public key.
         /// <remarks>
         /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
@@ -111,6 +123,17 @@ namespace Solnet.Rpc
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         RequestResult<ResponseValue<ulong>> GetBalance(string pubKey, Commitment commitment = Commitment.Finalized);
+        
+        /// <summary>
+        /// Gets the balance <b>synchronously</b> for a certain public key.
+        /// <remarks>
+        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
+        /// </remarks>
+        /// </summary>
+        /// <param name="pubKey">The public key.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
+        RequestResult<ResponseValue<ulong>> GetBalance(PublicKey pubKey, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Returns identity and transaction information about a block in the ledger.

--- a/src/Solnet.Rpc/SolanaRpcClient.cs
+++ b/src/Solnet.Rpc/SolanaRpcClient.cs
@@ -5,6 +5,7 @@ using Solnet.Rpc.Messages;
 using Solnet.Rpc.Models;
 using Solnet.Rpc.Types;
 using Solnet.Rpc.Utilities;
+using Solnet.Wallet;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -199,11 +200,22 @@ namespace Solnet.Rpc
             return await SendRequestAsync<ResponseValue<ulong>>("getBalance",
                 Parameters.Create(pubKey, ConfigObject.Create(HandleCommitment(commitment))));
         }
+        /// <inheritdoc cref="IRpcClient.GetBalanceAsync"/>
+        public async Task<RequestResult<ResponseValue<ulong>>> GetBalanceAsync(PublicKey pubKey, Commitment commitment = Commitment.Finalized)
+        {
+            return await SendRequestAsync<ResponseValue<ulong>>("getBalance",
+                Parameters.Create(pubKey.Key, ConfigObject.Create(HandleCommitment(commitment))));
+        }
 
         /// <inheritdoc cref="IRpcClient.GetBalance"/>
         public RequestResult<ResponseValue<ulong>> GetBalance(string pubKey,
             Commitment commitment = Commitment.Finalized)
             => GetBalanceAsync(pubKey, commitment).Result;
+        /// <inheritdoc cref="IRpcClient.GetBalance"/>
+        public RequestResult<ResponseValue<ulong>> GetBalance(PublicKey pubKey, Commitment commitment = Commitment.Finalized)
+        {
+            return GetBalanceAsync(pubKey, commitment).Result;
+        }
 
         #region Blocks
 


### PR DESCRIPTION

## Problem

`GetBalance()` method in `IRpcClient` only accepts string (aka `Publickey` key)


## Solution

Add an overload to `GetBalance()` with `PublicKey`


