### PR TITLE
Fixed transaction and AccountKeyList populate

### DIFF
--- a/src/Solnet.Rpc/Models/AccountKeysList.cs
+++ b/src/Solnet.Rpc/Models/AccountKeysList.cs
@@ -70,10 +70,14 @@ namespace Solnet.Rpc.Models
             {
                 _accounts.Add(accountMeta);
             }
-            else if (!accMeta.IsSigner && accountMeta.IsSigner || !accMeta.IsWritable && accountMeta.IsWritable)
+            else if (!accMeta.IsSigner && accountMeta.IsSigner)
             {
-                var idx = _accounts.IndexOf(accMeta);
-                _accounts[idx] = accountMeta;
+                accMeta.IsSigner = true;
+                accMeta.IsWritable = accMeta.IsWritable || accountMeta.IsWritable;
+            }
+            else if(!accMeta.IsWritable && accountMeta.IsWritable)
+            {
+                accMeta.IsWritable = true;
             }
 
         }

--- a/src/Solnet.Rpc/Models/AccountMeta.cs
+++ b/src/Solnet.Rpc/Models/AccountMeta.cs
@@ -22,12 +22,12 @@ namespace Solnet.Rpc.Models
         /// <summary>
         /// A boolean which defines if the account is a signer account.
         /// </summary>
-        public bool IsSigner { get; }
+        public bool IsSigner { get; internal set; }
 
         /// <summary>
         /// A boolean which defines if the account is a writable account.
         /// </summary>
-        public bool IsWritable { get; }
+        public bool IsWritable { get; internal set; }
 
         /// <summary>
         /// Initialize the account meta with the passed public key, being a non-signing account for the transaction.

--- a/src/Solnet.Rpc/Models/Message.cs
+++ b/src/Solnet.Rpc/Models/Message.cs
@@ -102,6 +102,13 @@ namespace Solnet.Rpc.Models
                                                      index < AccountKeys.Count - Header.ReadOnlyUnsignedAccounts);
 
         /// <summary>
+        /// Check whether an account is a signer.
+        /// </summary>
+        /// <param name="index">The index of the account in the account keys.</param>
+        /// <returns>true if the account is an expected signer, false otherwise.</returns>
+        public bool IsAccountSigner(int index) => index < Header.RequiredSignatures;
+
+        /// <summary>
         /// Serialize the message into the wire format.
         /// </summary>
         /// <returns>A byte array corresponding to the serialized message.</returns>

--- a/src/Solnet.Rpc/Models/Transaction.cs
+++ b/src/Solnet.Rpc/Models/Transaction.cs
@@ -325,7 +325,7 @@ namespace Solnet.Rpc.Models
                 {
                     int k = compiledInstruction.KeyIndices[j];
                     accounts.Add(new AccountMeta(message.AccountKeys[k], message.IsAccountWritable(k),
-                        tx.Signatures.Any(pair => pair.PublicKey.Key == message.AccountKeys[k].Key)));
+                        tx.Signatures.Any(pair => pair.PublicKey.Key == message.AccountKeys[k].Key) || message.IsAccountSigner(k)));
                 }
 
                 TransactionInstruction instruction = new()


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | Yes | Closes #296  |

## Problem

Messages not being properly signed.
Issue was in Transaction.Populate not taking into account signers not required by transactions being 'downgraded' into read-only accounts.

## Solution

Properly handling of Transaction Populate edge cases to allow signers not required by any instructions.
Additional fix to AccountKeyList handling of permissions.