### PR TITLE
Changed string ser/des names to avoid confusion.

### DIFF
--- a/src/Solnet.Programs/Models/NameService/ReverseNameRecord.cs
+++ b/src/Solnet.Programs/Models/NameService/ReverseNameRecord.cs
@@ -44,7 +44,7 @@ namespace Solnet.Programs.Models.NameService
             var data = new ReadOnlySpan<byte>(input, 96, input.Length - 96);
 
             var header = RecordHeader.Deserialize(input);
-            _ = data.GetString(0, out var str);
+            _ = data.GetBorshString(0, out var str);
 
             var res = new ReverseNameRecord(header, str);
 

--- a/src/Solnet.Programs/Models/NameService/ReverseTwitteRecord.cs
+++ b/src/Solnet.Programs/Models/NameService/ReverseTwitteRecord.cs
@@ -46,7 +46,7 @@ namespace Solnet.Programs.Models.NameService
             var ret = new ReverseTwitterRecord(header);
 
             ret.TwitterRegistryKey = data.GetPubKey(0);
-            _ = data.GetString(32, out var str);
+            _ = data.GetBorshString(32, out var str);
             ret.TwitterHandle = str;
 
             return ret;

--- a/src/Solnet.Programs/Models/NameService/TokenData.cs
+++ b/src/Solnet.Programs/Models/NameService/TokenData.cs
@@ -53,8 +53,8 @@ namespace Solnet.Programs.Models.NameService
             var data = new ReadOnlySpan<byte>(input, 96, input.Length - 96);
             int offset = 0;
 
-            offset += data.GetString(0, out var name);
-            offset += data.GetString(offset, out var ticker);
+            offset += data.GetBorshString(0, out var name);
+            offset += data.GetBorshString(offset, out var ticker);
 
             var mint = data.GetPubKey(offset);
             offset += 32;
@@ -64,10 +64,10 @@ namespace Solnet.Programs.Models.NameService
             string website = null, logo = null;
 
             if (data.GetBool(offset++))
-                offset += data.GetString(offset, out website);
+                offset += data.GetBorshString(offset, out website);
 
             if (data.GetBool(offset++))
-                data.GetString(offset, out logo);
+                data.GetBorshString(offset, out logo);
 
             return new TokenData() { Name = name, Ticker = ticker, Decimals = decimals, LogoUri = logo, Mint = mint, Website = website };
         }

--- a/src/Solnet.Programs/Stake/StakeProgramData.cs
+++ b/src/Solnet.Programs/Stake/StakeProgramData.cs
@@ -104,7 +104,7 @@ namespace Solnet.Programs
 
         internal static byte[] EncodeAuthorizeWithSeedData(string authoritySeed, PublicKey newAuthorizedPubKey, StakeAuthorize stakeAuthorize, PublicKey authorityOwner)
         {
-            byte[] encodedSeed = Serialization.EncodeRustString(authoritySeed);
+            byte[] encodedSeed = Serialization.EncodeBincodeString(authoritySeed);
             byte[] data = new byte[72 + encodedSeed.Length];
 
             data.WriteU32((uint)StakeProgramInstructions.Values.AuthorizeWithSeed, MethodOffset);
@@ -134,7 +134,7 @@ namespace Solnet.Programs
 
         internal static byte[] EncodeAuthorizeCheckedWithSeedData(string authoritySeed, PublicKey authorityOwner, StakeAuthorize stakeAuthorize)
         {
-            byte[] encodedSeed = Serialization.EncodeRustString(authoritySeed);
+            byte[] encodedSeed = Serialization.EncodeBincodeString(authoritySeed);
             byte[] data = new byte[40 + encodedSeed.Length];
 
             data.WriteU32((uint)StakeProgramInstructions.Values.AuthorizeCheckedWithSeed, MethodOffset);
@@ -219,7 +219,7 @@ namespace Solnet.Programs
             decodedInstruction.Values.Add("Custodian Account", keys[keyIndices[3]]);
             decodedInstruction.Values.Add("New Authorized Account", data.GetPubKey(4));
             decodedInstruction.Values.Add("Stake Authorize", Enum.Parse(typeof(StakeAuthorize), data.GetU8(36).ToString()));
-            (string authoritySeed, int seedLength) = data.DecodeRustString(37);
+            (string authoritySeed, int seedLength) = data.DecodeBincodeString(37);
             decodedInstruction.Values.Add("Authority Seed", authoritySeed);
             decodedInstruction.Values.Add("Authority Owner Account", data.GetPubKey(37 + seedLength));
         }  
@@ -250,7 +250,7 @@ namespace Solnet.Programs
             decodedInstruction.Values.Add("Custodian Account", keys[keyIndices[4]]);
             decodedInstruction.Values.Add("New Authorized Account", keys[keyIndices[3]]);
             decodedInstruction.Values.Add("Stake Authorize", Enum.Parse(typeof(StakeAuthorize), data.GetU8(4).ToString()));
-            (string authoritySeed, int seedLength) = data.DecodeRustString(5);
+            (string authoritySeed, int seedLength) = data.DecodeBincodeString(5);
             decodedInstruction.Values.Add("Authority Seed", authoritySeed);
             decodedInstruction.Values.Add("Authority Owner Account", data.GetPubKey(5 + seedLength));
         }

--- a/src/Solnet.Programs/SystemProgramData.cs
+++ b/src/Solnet.Programs/SystemProgramData.cs
@@ -76,7 +76,7 @@ namespace Solnet.Programs
         internal static byte[] EncodeCreateAccountWithSeedData(
             PublicKey baseAccount, PublicKey owner, ulong lamports, ulong space, string seed)
         {
-            byte[] encodedSeed = Serialization.EncodeRustString(seed);
+            byte[] encodedSeed = Serialization.EncodeBincodeString(seed);
             byte[] data = new byte[84 + encodedSeed.Length];
 
             data.WriteU32((uint)SystemProgramInstructions.Values.CreateAccountWithSeed, MethodOffset);
@@ -175,7 +175,7 @@ namespace Solnet.Programs
         internal static byte[] EncodeAllocateWithSeedData(
             PublicKey baseAccount, PublicKey owner, ulong space, string seed)
         {
-            byte[] encodedSeed = Serialization.EncodeRustString(seed);
+            byte[] encodedSeed = Serialization.EncodeBincodeString(seed);
             byte[] data = new byte[76 + encodedSeed.Length];
 
             data.WriteU32((uint)SystemProgramInstructions.Values.AllocateWithSeed, MethodOffset);
@@ -197,7 +197,7 @@ namespace Solnet.Programs
         internal static byte[] EncodeAssignWithSeedData(
             PublicKey baseAccount, string seed, PublicKey owner)
         {
-            byte[] encodedSeed = Serialization.EncodeRustString(seed);
+            byte[] encodedSeed = Serialization.EncodeBincodeString(seed);
             byte[] data = new byte[68 + encodedSeed.Length];
 
             data.WriteU32((uint)SystemProgramInstructions.Values.AssignWithSeed, MethodOffset);
@@ -217,7 +217,7 @@ namespace Solnet.Programs
         /// <returns>The transaction instruction data.</returns>
         internal static byte[] EncodeTransferWithSeedData(PublicKey owner, string seed, ulong lamports)
         {
-            byte[] encodedSeed = Serialization.EncodeRustString(seed);
+            byte[] encodedSeed = Serialization.EncodeBincodeString(seed);
             byte[] data = new byte[44 + encodedSeed.Length];
 
             data.WriteU32((uint)SystemProgramInstructions.Values.TransferWithSeed, MethodOffset);
@@ -286,7 +286,7 @@ namespace Solnet.Programs
             decodedInstruction.Values.Add("From Account", keys[keyIndices[0]]);
             decodedInstruction.Values.Add("To Account", keys[keyIndices[1]]);
             decodedInstruction.Values.Add("Base Account", data.GetPubKey(4));
-            (string createSeed, int createLength) = data.DecodeRustString(36);
+            (string createSeed, int createLength) = data.DecodeBincodeString(36);
             decodedInstruction.Values.Add("Seed", createSeed);
             decodedInstruction.Values.Add("Amount", data.GetU64(36 + createLength));
             decodedInstruction.Values.Add("Space", data.GetU64(44 + createLength));
@@ -377,7 +377,7 @@ namespace Solnet.Programs
         {
             decodedInstruction.Values.Add("Account", keys[keyIndices[0]]);
             decodedInstruction.Values.Add("Base Account", data.GetPubKey(4));
-            (string allocateSeed, int allocateLength) = data.DecodeRustString(36);
+            (string allocateSeed, int allocateLength) = data.DecodeBincodeString(36);
             decodedInstruction.Values.Add("Seed", allocateSeed);
             decodedInstruction.Values.Add("Space", data.GetU64(36 + allocateLength));
             decodedInstruction.Values.Add("Owner", data.GetPubKey(44 + allocateLength));
@@ -395,7 +395,7 @@ namespace Solnet.Programs
         {
             decodedInstruction.Values.Add("Account", keys[keyIndices[0]]);
             decodedInstruction.Values.Add("Base Account", data.GetPubKey(4));
-            (string assignSeed, int assignLength) = data.DecodeRustString(36);
+            (string assignSeed, int assignLength) = data.DecodeBincodeString(36);
             decodedInstruction.Values.Add("Seed", assignSeed);
             decodedInstruction.Values.Add("Owner", data.GetPubKey(36 + assignLength));
         }
@@ -414,7 +414,7 @@ namespace Solnet.Programs
             decodedInstruction.Values.Add("From Base Account", keys[keyIndices[1]]);
             decodedInstruction.Values.Add("To Account", keys[keyIndices[1]]);
             decodedInstruction.Values.Add("Amount", data.GetU64(4));
-            (string transferSeed, int transferLength) = data.DecodeRustString(12);
+            (string transferSeed, int transferLength) = data.DecodeBincodeString(12);
             decodedInstruction.Values.Add("Seed", transferSeed);
             decodedInstruction.Values.Add("From Owner", data.GetPubKey(12 + transferLength));
         }

--- a/src/Solnet.Programs/Utilities/Deserialization.cs
+++ b/src/Solnet.Programs/Utilities/Deserialization.cs
@@ -223,7 +223,7 @@ namespace Solnet.Programs.Utilities
         /// <param name="offset">The offset at which the string begins.</param>
         /// <returns>The decoded data.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the offset is too big for the span.</exception>
-        public static (string EncodedString, int Length) DecodeRustString(this ReadOnlySpan<byte> data, int offset)
+        public static (string EncodedString, int Length) DecodeBincodeString(this ReadOnlySpan<byte> data, int offset)
         {
             if (offset + sizeof(ulong) > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
@@ -242,7 +242,7 @@ namespace Solnet.Programs.Utilities
         /// <param name="result">The decoded data./>.</param>
         /// <returns>The length in bytes that was read from the original buffer, including the</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the offset is too big for the span.</exception>
-        public static int GetString(this ReadOnlySpan<byte> data, int offset, out string result)
+        public static int GetBorshString(this ReadOnlySpan<byte> data, int offset, out string result)
         {
             if (offset + sizeof(uint) > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));

--- a/src/Solnet.Programs/Utilities/Serialization.cs
+++ b/src/Solnet.Programs/Utilities/Serialization.cs
@@ -218,7 +218,7 @@ namespace Solnet.Programs.Utilities
         /// <param name="value">The <see cref="string"/> to write.</param>
         /// <param name="offset">The offset at which to write the <see cref="string"/>.</param>
         /// <returns>Returns the number of bytes written.</returns>
-        public static int WriteString(this byte[] data, string value, int offset)
+        public static int WriteBorshString(this byte[] data, string value, int offset)
         {
             byte[] stringBytes = Encoding.UTF8.GetBytes(value);
 
@@ -236,7 +236,7 @@ namespace Solnet.Programs.Utilities
         /// </summary>
         /// <param name="data"> the string to be encoded</param>
         /// <returns></returns>
-        public static byte[] EncodeRustString(string data)
+        public static byte[] EncodeBincodeString(string data)
         {
             byte[] stringBytes = Encoding.UTF8.GetBytes(data);
           

--- a/test/Solnet.Programs.Test/Utilities/DeserializationUtilitiesTest.cs
+++ b/test/Solnet.Programs.Test/Utilities/DeserializationUtilitiesTest.cs
@@ -407,7 +407,7 @@ namespace Solnet.Programs.Test.Utilities
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void TestReadRustStringException()
         {
-            Deserialization.DecodeRustString(EncodedStringBytes, 22);
+            Deserialization.DecodeBincodeString(EncodedStringBytes, 22);
         }
 
         [TestMethod]
@@ -417,7 +417,7 @@ namespace Solnet.Programs.Test.Utilities
             const string expected = "this is a test string";
             int expectedLength = expected.Length + sizeof(ulong);
 
-            (string actual, int length) = Deserialization.DecodeRustString(EncodedStringBytes, 0);
+            (string actual, int length) = Deserialization.DecodeBincodeString(EncodedStringBytes, 0);
 
             Assert.AreEqual(expected, actual);
             Assert.AreEqual(expectedLength, length);

--- a/test/Solnet.Programs.Test/Utilities/SerializationUtilitiesTest.cs
+++ b/test/Solnet.Programs.Test/Utilities/SerializationUtilitiesTest.cs
@@ -257,7 +257,7 @@ namespace Solnet.Programs.Test.Utilities
         {
             const string value = "this is a test string";
 
-            byte[] encodedString = Serialization.EncodeRustString(value);
+            byte[] encodedString = Serialization.EncodeBincodeString(value);
 
             CollectionAssert.AreEqual(EncodedStringBytes, encodedString);
         }


### PR DESCRIPTION

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready/Hold | Feature/Bug/Tooling/Refactor/Hotfix | Yes/No | [Link](<Issue link here>) |

## Problem

String serialization and deserialization method names are ambiguous.


## Solution

Changed these method names to be more explicit in what they do.