### PR TITLE
Fixes WriteBorshString ignoring offset

### DIFF
--- a/src/Solnet.Programs/Utilities/Serialization.cs
+++ b/src/Solnet.Programs/Utilities/Serialization.cs
@@ -225,8 +225,8 @@ namespace Solnet.Programs.Utilities
             if(offset + sizeof(uint) + stringBytes.Length > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
 
-            data.WriteU32((uint)stringBytes.Length, 0);
-            data.WriteSpan(stringBytes, sizeof(uint));
+            data.WriteU32((uint)stringBytes.Length, offset);
+            data.WriteSpan(stringBytes, offset + sizeof(uint));
 
             return stringBytes.Length + sizeof(uint);
         }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Hotfix | Yes | Closes #321 |

## Problem

_What problem are you trying to solve?_

`WriteBorshString` would ignore the offset parameter and overwrite at offset 0 of the destination buffer

## Solution

_How did you solve the problem?_

Used the correct offset for the underlying `WriteU32` and `WriteSpan` calls
