### PR TITLE
Fixed negative BigInteger not being properly serialized.

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>0.6.3</Version>
+    <Version>0.6.4</Version>
     <Copyright>Copyright 2021 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Programs/Utilities/Serialization.cs
+++ b/src/Solnet.Programs/Utilities/Serialization.cs
@@ -162,22 +162,29 @@ namespace Solnet.Programs.Utilities
         /// <param name="data">The byte array to get data from.</param>
         /// <param name="bigInteger">The <see cref="BigInteger"/> to write.</param>
         /// <param name="offset">The offset at which to write the <see cref="BigInteger"/>.</param>
+        /// <param name="length">The length in bytes.</param>
         /// <param name="isUnsigned">Whether the value does not use signed encoding.</param>
         /// <param name="isBigEndian">Whether the value is in big-endian byte order.</param>
         /// <returns>An integer representing the number of bytes written to the byte array.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the offset is too big for the data array.</exception>
-        public static int WriteBigInt(this byte[] data, BigInteger bigInteger, int offset,
+        public static int WriteBigInt(this byte[] data, BigInteger bigInteger, int offset, int length,
             bool isUnsigned = false, bool isBigEndian = false)
         {
             int byteCount = bigInteger.GetByteCount(isUnsigned);
-            if (offset + byteCount > data.Length)
-                throw new ArgumentOutOfRangeException(nameof(offset));
+            if (byteCount > length) throw new ArgumentOutOfRangeException($"BigInt too big.");
+            if (length + offset > data.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             bigInteger.TryWriteBytes(
                 data.AsSpan(offset, byteCount),
                 out int written,
                 isUnsigned,
                 isBigEndian);
+
+            if(!isUnsigned && bigInteger.Sign < 0)
+            {
+                while (written < length) data[offset + written++] = 0xFF;
+            }
+
             return written;
         }
 

--- a/test/Solnet.Programs.Test/Utilities/DeserializationUtilitiesTest.cs
+++ b/test/Solnet.Programs.Test/Utilities/DeserializationUtilitiesTest.cs
@@ -422,5 +422,21 @@ namespace Solnet.Programs.Test.Utilities
             Assert.AreEqual(expected, actual);
             Assert.AreEqual(expectedLength, length);
         }
+
+        [TestMethod]
+        public void TestBigIntSerDes()
+        {
+            BigInteger bi = new BigInteger(long.MinValue);
+
+            byte[] buffer = new byte[16];
+
+            buffer.WriteBigInt(bi, 0, 16);
+
+            var span = new ReadOnlySpan<byte>(buffer);
+
+            var bi2 = span.GetBigInt(0, 16);
+
+            Assert.AreEqual(bi, bi2);
+        }
     }
 }

--- a/test/Solnet.Programs.Test/Utilities/SerializationUtilitiesTest.cs
+++ b/test/Solnet.Programs.Test/Utilities/SerializationUtilitiesTest.cs
@@ -198,8 +198,20 @@ namespace Solnet.Programs.Test.Utilities
         public void TestWriteBigIntegerException()
         {
             byte[] sut = new byte[16];
-            sut.WriteBigInt(new BigInteger(15000000000000000000000000D), 8);
+            sut.WriteBigInt(new BigInteger(15000000000000000000000000D), 8, 16);
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TestWriteBigIntegerException2()
+        {
+            BigInteger bi = BigInteger.Parse("34028236692093846346337460743176821145");
+
+            byte[] buffer = new byte[10];
+
+            buffer.WriteBigInt(bi, 0, 10);
+        }
+
 
         [TestMethod]
         public void TestWriteBigInteger()
@@ -207,7 +219,7 @@ namespace Solnet.Programs.Test.Utilities
             byte[] sut = new byte[16];
             BigInteger bi = BigInteger.Parse("34028236692093846346337460743176821145");
 
-            int written = sut.WriteBigInt(bi, 0);
+            int written = sut.WriteBigInt(bi, 0, 16);
 
             Assert.AreEqual(bi.GetByteCount(), written);
             CollectionAssert.AreEqual(new byte[]


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | Yes | [Link](<Issue link here>) |

## Problem

Negative BigIntegers are not properly serialized.


## Solution

Fixed BigInteger serialization. Added more relevant unit tests.