### PR TITLE
Qol and bugfix net5

### DIFF
--- a/src/Solnet.Programs/Abstract/Program.cs
+++ b/src/Solnet.Programs/Abstract/Program.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace Solnet.Programs.Abstract
 {
+    /// <summary>
+    /// Base Program interface.
+    /// </summary>
     public interface Program
     {
         /// <summary>

--- a/src/Solnet.Programs/NameServiceProgram.cs
+++ b/src/Solnet.Programs/NameServiceProgram.cs
@@ -75,7 +75,8 @@ namespace Solnet.Programs
         {
             string prefixedName = HashPrefix + name;
             byte[] fullNameBytes = Encoding.UTF8.GetBytes(prefixedName);
-            using SHA256Managed sha = new();
+
+            using SHA256 sha = SHA256.Create();
             return sha.ComputeHash(fullNameBytes, 0, fullNameBytes.Length);
         }
 

--- a/src/Solnet.Programs/TokenSwap/Models/TokenSwapAccount.cs
+++ b/src/Solnet.Programs/TokenSwap/Models/TokenSwapAccount.cs
@@ -16,7 +16,13 @@ namespace Solnet.Programs.TokenSwap.Models
         /// <summary>
         /// Versions of this state account
         /// </summary>
-        public enum SwapVersion { SwapV1 = 1 }
+        public enum SwapVersion 
+        { 
+            /// <summary>
+            /// Version 1.
+            /// </summary>
+            SwapV1 = 1 
+        }
 
         /// <summary>
         /// Version of this state account

--- a/src/Solnet.Rpc/ClientFactory.cs
+++ b/src/Solnet.Rpc/ClientFactory.cs
@@ -30,7 +30,7 @@ namespace Solnet.Rpc
         /// <summary>
         /// The dev net cluster.
         /// </summary>
-        private const string StreamingRpcDevNet = "wss://devnet.solana.com";
+        private const string StreamingRpcDevNet = "wss://api.devnet.solana.com";
 
         /// <summary>
         /// The test net cluster.

--- a/src/Solnet.Wallet/PublicKey.cs
+++ b/src/Solnet.Wallet/PublicKey.cs
@@ -216,32 +216,32 @@ namespace Solnet.Wallet
         /// <param name="seeds">The address seeds.</param>
         /// <param name="programId">The program Id.</param>
         /// <param name="address">The derived address, returned as inline out.</param>
-        /// <param name="nonce">The nonce used to derive the address, returned as inline out.</param>
-        /// <returns>true whenever the address for a nonce was found, otherwise false.</returns>
-        public static bool TryFindProgramAddress(IEnumerable<byte[]> seeds, PublicKey programId, out PublicKey address, out byte nonce)
+        /// <param name="bump">The bump used to derive the address, returned as inline out.</param>
+        /// <returns>True whenever the address for a nonce was found, otherwise false.</returns>
+        public static bool TryFindProgramAddress(IEnumerable<byte[]> seeds, PublicKey programId, out PublicKey address, out byte bump)
         {
-            byte derivationNonce = 255;
+            byte seedBump = 255;
             List<byte[]> buffer = seeds.ToList();
-            var nonceArray = new byte[1];
-            buffer.Add(nonceArray);
+            var bumpArray = new byte[1];
+            buffer.Add(bumpArray);
 
-            while (derivationNonce != 0)
+            while (seedBump != 0)
             {
-                nonceArray[0] = derivationNonce;
+                bumpArray[0] = seedBump;
                 bool success = TryCreateProgramAddress(buffer, programId, out PublicKey derivedAddress);
 
                 if (success)
                 {
                     address = derivedAddress;
-                    nonce = derivationNonce;
+                    bump = seedBump;
                     return true;
                 }
 
-                derivationNonce--;
+                seedBump--;
             }
 
             address = null;
-            nonce = 0;
+            bump = 0;
             return false;
         }
 
@@ -252,7 +252,8 @@ namespace Solnet.Wallet
         /// <param name="seed">The seed</param>
         /// <param name="programId">The programid</param>
         /// <param name="publicKeyOut">The derived public key</param>
-        /// <returns></returns>
+        /// <returns>True whenever the address was successfully created, otherwise false.</returns>
+        /// <remarks>To fail address creation, means the created address was a PDA.</remarks>
         public static bool TryCreateWithSeed(PublicKey fromPublicKey, string seed, PublicKey programId, out PublicKey publicKeyOut)
         {
             var b58 = new Base58Encoder();


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug/Refactor | No | Closes #336 |

## Problem

Nomenclature issues with seed bumps.
Wrong address used in devnet web sockets.
Deprecated api.

## Solution

Changed nonce -> bump;
Fixed devnet websocket address.
Replaced `new SHA256Managed()` with `SHA256.Create()`