### PR TITLE
Better error parsing net5

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <Copyright>Copyright 2022 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Rpc/Converters/RpcErrorResponseConverter.cs
+++ b/src/Solnet.Rpc/Converters/RpcErrorResponseConverter.cs
@@ -1,0 +1,79 @@
+using Solnet.Rpc.Messages;
+using Solnet.Rpc.Models;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Solnet.Rpc.Converters
+{
+    /// <summary>
+    /// Converts a TransactionError from json into its model representation.
+    /// </summary>
+    public class RpcErrorResponseConverter : JsonConverter<JsonRpcErrorResponse>
+    {
+        /// <summary>
+        /// Reads and converts the JSON to type <c>JsonRpcErrorResponse</c>.
+        /// </summary>
+        /// <param name="reader">The reader.</param>
+        /// <param name="typeToConvert"> The type to convert.</param>
+        /// <param name="options">An object that specifies serialization options to use.</param>
+        /// <returns>The converted value.</returns>
+        public override JsonRpcErrorResponse Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject) return null;
+
+            reader.Read();
+
+            var err = new JsonRpcErrorResponse();
+
+            while (reader.TokenType != JsonTokenType.EndObject)
+            {
+                var prop = reader.GetString();
+
+                reader.Read();
+
+                if ("jsonrpc" == prop)
+                {
+                    // do nothing
+                }
+                else if ("id" == prop)
+                {
+                    err.Id = reader.GetInt32();
+                }
+                else if ("error" == prop)
+                {
+                    if(reader.TokenType == JsonTokenType.String)
+                    {
+                        err.ErrorMessage = reader.GetString();
+                    }
+                    else if(reader.TokenType == JsonTokenType.StartObject)
+                    {
+                        err.Error = JsonSerializer.Deserialize<ErrorContent>(ref reader, options);
+                    }
+                    else
+                    {
+                        reader.TrySkip();
+                    }
+                }
+                else
+                {
+                    reader.TrySkip();
+                }
+
+                reader.Read();
+            }
+            return err;
+        }
+
+        /// <summary>
+        /// Not implemented.
+        /// </summary>
+        /// <param name="writer">n/a</param>
+        /// <param name="value">n/a</param>
+        /// <param name="options">n/a</param>
+        public override void Write(Utf8JsonWriter writer, JsonRpcErrorResponse value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Solnet.Rpc/Core/Http/IRequestResult.cs
+++ b/src/Solnet.Rpc/Core/Http/IRequestResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Solnet.Rpc.Models;
+using System.Collections.Generic;
 using System.Net;
 
 namespace Solnet.Rpc.Core.Http
@@ -41,7 +42,7 @@ namespace Solnet.Rpc.Core.Http
         /// <summary>
         /// The error data, if applicable.
         /// </summary>
-        Dictionary<string, object> ErrorData { get; set; }
+        SimulationLogs ErrorData { get; set; }
 
         /// <summary>
         /// Contains the JSON RPC request payload

--- a/src/Solnet.Rpc/Core/Http/IRequestResult.cs
+++ b/src/Solnet.Rpc/Core/Http/IRequestResult.cs
@@ -42,7 +42,7 @@ namespace Solnet.Rpc.Core.Http
         /// <summary>
         /// The error data, if applicable.
         /// </summary>
-        SimulationLogs ErrorData { get; set; }
+        ErrorData ErrorData { get; set; }
 
         /// <summary>
         /// Contains the JSON RPC request payload

--- a/src/Solnet.Rpc/Core/Http/JsonRpcClient.cs
+++ b/src/Solnet.Rpc/Core/Http/JsonRpcClient.cs
@@ -155,6 +155,10 @@ namespace Solnet.Rpc.Core.Http
                         result.ServerErrorCode = errorRes.Error.Code;
                         result.ErrorData = errorRes.Error.Data;
                     }
+                    else if(errorRes is { ErrorMessage: { } })
+                    {
+                        result.Reason = errorRes.ErrorMessage;
+                    }
                     else
                     {
                         result.Reason = "Something wrong happened.";
@@ -260,6 +264,10 @@ namespace Solnet.Rpc.Core.Http
                         result.Reason = errorRes.Error.Message;
                         result.ServerErrorCode = errorRes.Error.Code;
                         result.ErrorData = errorRes.Error.Data;
+                    }
+                    else if (errorRes is { ErrorMessage: { } })
+                    {
+                        result.Reason = errorRes.ErrorMessage;
                     }
                     else
                     {

--- a/src/Solnet.Rpc/Core/Http/RequestResult.cs
+++ b/src/Solnet.Rpc/Core/Http/RequestResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Solnet.Rpc.Models;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 
@@ -48,7 +49,7 @@ namespace Solnet.Rpc.Core.Http
         /// <summary>
         /// The error data, if applicable.
         /// </summary>
-        public Dictionary<string, object> ErrorData { get; set; }
+        public ErrorData ErrorData { get; set; }
 
         /// <summary>
         /// Contains the JSON RPC request payload

--- a/src/Solnet.Rpc/Messages/JsonRpcResponse.cs
+++ b/src/Solnet.Rpc/Messages/JsonRpcResponse.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using Solnet.Rpc.Converters;
+using Solnet.Rpc.Models;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Solnet.Rpc.Messages
@@ -18,12 +20,18 @@ namespace Solnet.Rpc.Messages
     /// <summary>
     /// Error message from a given request.
     /// </summary>
+    [JsonConverter(typeof(RpcErrorResponseConverter))]
     public class JsonRpcErrorResponse : JsonRpcBase
     {
         /// <summary>
-        /// The error message.
+        /// The detailed error desserialized.
         /// </summary>
         public ErrorContent Error { get; set; }
+
+        /// <summary>
+        /// An error message.
+        /// </summary>
+        public string ErrorMessage { get; set; }
     }
 
     /// <summary>
@@ -43,8 +51,7 @@ namespace Solnet.Rpc.Messages
         /// <summary>
         /// Possible extension data as a dictionary.
         /// </summary>
-        [JsonExtensionData]
-        public Dictionary<string, object> Data { get; set; }
+        public ErrorData Data { get; set; }
     }
 
     /// <summary>

--- a/src/Solnet.Rpc/Models/Logs.cs
+++ b/src/Solnet.Rpc/Models/Logs.cs
@@ -61,4 +61,16 @@ namespace Solnet.Rpc.Models
         /// </summary>
         public string[] Logs { get; set; }
     }
+
+    /// <summary>
+    /// Represents a complete error message.
+    /// </summary>
+    /// <remarks>See RpcError::RpcResponseError in solana\client\src\rpc_request.rs</remarks>
+    public class ErrorData : SimulationLogs
+    {
+        /// <summary>
+        /// Represents the number of compute units consumed by the transactions.
+        /// </summary>
+        public ulong UnitsConsumed { get; set; }
+    }
 }

--- a/test/Solnet.Rpc.Test/Resources/Http/StringErrorResponse.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/StringErrorResponse.json
@@ -1,0 +1,1 @@
+{"jsonrpc":"2.0","error":"something wrong","id":0}

--- a/test/Solnet.Rpc.Test/SolanaRpcClientTest.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientTest.cs
@@ -48,6 +48,39 @@ namespace Solnet.Rpc.Test
             Assert.AreEqual(responseData, result.RawRpcResponse);
 
         }
+        [TestMethod]
+        public void TestStringErrorResponse()
+        {
+            var responseData = File.ReadAllText("Resources/Http/StringErrorResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/EmptyPayloadRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+
+            var result = sut.GetBalance("");
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result);
+            Assert.IsNull(result.Result);
+            Assert.IsTrue(result.WasHttpRequestSuccessful);
+            Assert.IsFalse(result.WasRequestSuccessfullyHandled);
+            Assert.IsFalse(result.WasSuccessful);
+            Assert.AreEqual("something wrong", result.Reason);
+            Assert.AreEqual(0, result.ServerErrorCode);
+            Assert.AreEqual(null, result.ErrorData);
+            Assert.IsNotNull(result.RawRpcRequest);
+            Assert.IsNotNull(result.RawRpcResponse);
+            Assert.AreEqual(requestData, result.RawRpcRequest);
+            Assert.AreEqual(responseData, result.RawRpcResponse);
+
+        }
 
         [TestMethod]
         public void TestBadAddressExceptionRequest()

--- a/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
+++ b/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
@@ -126,6 +126,9 @@
     <None Update="Resources\Http\Blocks\GetBlocksResponse.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Http\StringErrorResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Http\GetProgramAccountsResponse-Fail-410.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Refactor | Yes | [Link](<Issue link here>) |

## Problem

Error parsing was lackluster.


## Solution

Refactored error parsing. Should allow better access to transaction preflight errors.