### PR TITLE
small performance improvement by using unsafe code

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>6.0.3</Version>
+    <Version>6.0.4</Version>
     <Copyright>Copyright 2022 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Programs/Solnet.Programs.csproj
+++ b/src/Solnet.Programs/Solnet.Programs.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Solnet.Programs/Utilities/Serialization.cs
+++ b/src/Solnet.Programs/Utilities/Serialization.cs
@@ -35,11 +35,11 @@ namespace Solnet.Programs.Utilities
         /// <param name="value">The boolean value to write.</param>
         /// <param name="offset">The offset at which to write the 8-bit unsigned integer.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the offset is too big for the data array.</exception>
-        public static void WriteBool(this byte[] data, bool value, int offset)
+        public static unsafe void WriteBool(this byte[] data, bool value, int offset)
         {
             if (offset > data.Length - sizeof(byte))
                 throw new ArgumentOutOfRangeException(nameof(offset));
-            data[offset] = value ? (byte)1 : (byte)0;
+            data[offset] =  *((byte*)(&value));;
         }
 
         /// <summary>


### PR DESCRIPTION
> ⚠️ NOTE: Use notes like this to emphasize something important about the PR.
>  
>  This could include other PRs this PR is built on top of; API breaking changes; reasons for why the PR is on hold; or anything else you would like to draw attention to.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Optimization | No | NO|

## Problem

A  tiny performance gain in serialization utility ( see [this](https://stackoverflow.com/questions/4980881/what-is-fastest-way-to-convert-bool-to-byte)).


## Solution

using `unsafe` code without explicit converting and also removing branching.


## Before & After Performance

```
BenchmarkDotNet=v0.13.1, OS=pop 21.10
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.102
  [Host]     : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT
  DefaultJob : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT


|                    Method |     Mean |   Error |  StdDev | Allocated |
|-------------------------- |---------:|--------:|--------:|----------:|
| explicit_branching_assign | 504.0 ns | 2.01 ns | 1.78 ns |         - |
|             unsafe_assing | 205.7 ns | 0.99 ns | 0.92 ns |         - |
```
## Benchmark Code

```csharp


using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

namespace Benchmark
{
    [MemoryDiagnoser]
    public  class Benchmark
    {
        private static byte _dummy;
        [Benchmark]
        public void explicit_branching_assign()
        {
            byte result = 0;
            var _the_bool = DateTimeOffset.Now.ToUnixTimeMilliseconds() % 2 ==0;
            for (var i = 0; i < 500; i++)
            {
                result = _the_bool ? (byte) (1) : (byte) 0;
            }
            _dummy = result ;
        }

        [Benchmark]
        public  unsafe void unsafe_assing(){
            byte result = 0;
            var _the_bool = DateTimeOffset.Now.ToUnixTimeMilliseconds() % 2 ==0;
            for (var i = 0; i < 500; i++)
            {
                result = *((byte*)(&_the_bool));
            }
            _dummy = result ;
        }
    }
    public static class MainClass
    {
        public static void Main()
        {
            var result = BenchmarkRunner.Run<Benchmark>();
        }
    }
}

```