### PR TITLE
Bad request setup when trying to fetch all names owned by a given add…

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>6.0.5</Version>
+    <Version>6.0.6</Version>
     <Copyright>Copyright 2022 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Programs/Clients/NameServiceClient.cs
+++ b/src/Solnet.Programs/Clients/NameServiceClient.cs
@@ -309,7 +309,7 @@ namespace Solnet.Programs.Clients
                     addressesCopy.Clear();
                 }
 
-                var multipleAccs = await RpcClient.GetMultipleAccountsAsync(addressesCopy, Rpc.Types.Commitment.Confirmed);
+                var multipleAccs = await RpcClient.GetMultipleAccountsAsync(currentReq, Rpc.Types.Commitment.Confirmed);
 
                 if (!multipleAccs.WasSuccessful)
                 {


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | [Link](<Issue link here>) | 

## Problem

Unable to fetch addresses owned by a given address that owns more than 100 addresses.

## Solution

Fixed call to getMultipleAccounts possibly requesting more than 100 accounts.