### PR TITLE
use internal Hex to Byte[]

### DIFF
--- a/src/Solnet.KeyStore/Utils.cs
+++ b/src/Solnet.KeyStore/Utils.cs
@@ -8,65 +8,13 @@ namespace Solnet.KeyStore
     {
 
         /// <summary>
-        /// Helper function to convert a character to byte.
-        /// </summary>
-        /// <param name="character">The character to convert</param>
-        /// <param name="index">The value that represents the character's position.</param>
-        /// <param name="shift">Number of bits to shift.</param>
-        /// <returns>The corresponding byte.</returns>
-        /// <exception cref="FormatException">Throws format exception when the character is not a valid alphanumeric character.</exception>
-        private static byte FromCharacterToByte(char character, int index, int shift = 0)
-        {
-            var value = (byte)character;
-            if (0x40 < value && 0x47 > value || 0x60 < value && 0x67 > value)
-            {
-                if (0x40 == (0x40 & value))
-                    if (0x20 == (0x20 & value))
-                        value = (byte)((value + 0xA - 0x61) << shift);
-                    else
-                        value = (byte)((value + 0xA - 0x41) << shift);
-            }
-            else if (0x29 < value && 0x40 > value)
-            {
-                value = (byte)((value - 0x30) << shift);
-            }
-            else
-            {
-                throw new FormatException(
-                    $"Character '{character}' at index '{index}' is not valid alphanumeric character.");
-            }
-
-            return value;
-        }
-
-        /// <summary>
         /// Performs the hex to byte array conversion.
         /// </summary>
         /// <param name="value">The string to convert to byte array.</param>
         /// <returns>The corresponding byte array.</returns>
         private static byte[] HexToByteArrayInternal(string value)
         {
-            byte[] bytes = null;
-            if (string.IsNullOrEmpty(value))
-            {
-                bytes = new byte[] { };
-            }
-            else
-            {
-                var stringLength = value.Length;
-                var writeIndex = 0;
-                bytes = new byte[stringLength / 2]; // Initialize our byte array to hold the converted string.
-
-                for (var readIndex = 0; readIndex < value.Length; readIndex += 2)
-                {
-                    var upper = FromCharacterToByte(value[readIndex], readIndex, 4);
-                    var lower = FromCharacterToByte(value[readIndex + 1], readIndex + 1);
-
-                    bytes[writeIndex++] = (byte)(upper | lower);
-                }
-            }
-
-            return bytes;
+            return Convert.FromHexString(value);
         }
 
         /// <summary>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Optimization| No |

## Problem

The code base is using a hand made method to convert `hex string` to `byte[]` which is slower than the native implementation 
## Solution

Use internal hex converter

## Benchmark

```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

namespace benchmark
{
    [MemoryDiagnoser()]
    [DisassemblyDiagnoser()]
    public class Bench
    {
        private string value = "68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f"; //hex for "hello" * 31
        [Benchmark]
        public byte[] new_method()
        {
            if (string.IsNullOrEmpty(value))
            {
              return new byte[] { };
            }
            return Convert.FromHexString(value);
        }

        private static byte FromCharacterToByte(char character, int index, int shift = 0)
        {
            var value = (byte)character;
            if (0x40 < value && 0x47 > value || 0x60 < value && 0x67 > value)
            {
                if (0x40 == (0x40 & value))
                    if (0x20 == (0x20 & value))
                        value = (byte)((value + 0xA - 0x61) << shift);
                    else
                        value = (byte)((value + 0xA - 0x41) << shift);
            }
            else if (0x29 < value && 0x40 > value)
            {
                value = (byte)((value - 0x30) << shift);
            }
            else
            {
                throw new FormatException(
                    $"Character '{character}' at index '{index}' is not valid alphanumeric character.");
            }

            return value;
        }
        [Benchmark]
        public byte[] old_method()
        {
            byte[] bytes = null;
            if (string.IsNullOrEmpty(value))
            {
                bytes = new byte[] { };
            }
            else
            {
                var stringLength = value.Length;
                var writeIndex = 0;
                bytes = new byte[stringLength / 2]; // Initialize our byte array to hold the converted string.

                for (var readIndex = 0; readIndex < value.Length; readIndex += 2)
                {
                    var upper = FromCharacterToByte(value[readIndex], readIndex, 4);
                    var lower = FromCharacterToByte(value[readIndex + 1], readIndex + 1);

                    bytes[writeIndex++] = (byte)(upper | lower);
                }
            }
            return  bytes;
        }
    }
    
    public static class master
    {
        public static void Main()
        {
            var _becnh = new Bench();
            var r1 = _becnh.old_method();
            var r2 = _becnh.new_method();
            if (!r1.SequenceEqual(r2))
            {
                throw new Exception("not eq");
            }
            BenchmarkRunner.Run<Bench>();
        }
    }
}
```

## Benchmark Result

```
BenchmarkDotNet=v0.13.1, OS=pop 21.10
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.200
  [Host]     : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT
  DefaultJob : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT


|     Method |       Mean |   Error |  StdDev |  Gen 0 | Code Size | Allocated |
|----------- |-----------:|--------:|--------:|-------:|----------:|----------:|
| new_method |   399.6 ns | 8.05 ns | 9.89 ns | 0.0291 |     102 B |     184 B |
| old_method | 1,021.5 ns | 6.87 ns | 5.74 ns | 0.0286 |     532 B |     184 B |

```