### PR TITLE
Adds the getFeeForMessage and getHighestSnapshotSlot v1.9 methods

### DIFF
--- a/src/Solnet.Rpc/IRpcClient.cs
+++ b/src/Solnet.Rpc/IRpcClient.cs
@@ -455,6 +455,22 @@ namespace Solnet.Rpc
         RequestResult<ResponseValue<FeesInfo>> GetFees(Commitment commitment = Commitment.Finalized);
 
         /// <summary>
+        /// Get the fee the network will charge for a particular Message.
+        /// </summary>
+        /// <param name="message">The base-64 encoded message.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
+        Task<RequestResult<ResponseValue<ulong>>> GetFeeForMessageAsync(string message, Commitment commitment = Commitment.Finalized);
+
+        /// <summary>
+        /// Get the fee the network will charge for a particular Message.
+        /// </summary>
+        /// <param name="message">The base-64 encoded message.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
+        RequestResult<ResponseValue<ulong>> GetFeeForMessage(string message, Commitment commitment = Commitment.Finalized);
+
+        /// <summary>
         /// Returns the slot of the lowest confirmed block that has not been purged from the ledger.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
@@ -904,6 +920,18 @@ namespace Solnet.Rpc
         /// </summary>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         RequestResult<ulong> GetSnapshotSlot();
+
+        /// <summary>
+        /// Gets the highest slot that the node has a snapshot for.
+        /// </summary>
+        /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
+        Task<RequestResult<SnapshotSlotInfo>> GetHighestSnapshotSlotAsync();
+
+        /// <summary>
+        /// Gets the highest slot that the node has a snapshot for.
+        /// </summary>
+        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
+        RequestResult<SnapshotSlotInfo> GetHighestSnapshotSlot();
 
         /// <summary>
         /// Gets the epoch activation information for a stake account.

--- a/src/Solnet.Rpc/Models/SnapshotSlotInfo.cs
+++ b/src/Solnet.Rpc/Models/SnapshotSlotInfo.cs
@@ -1,0 +1,18 @@
+﻿namespace Solnet.Rpc.Models
+{
+    /// <summary>
+    /// The highest snapshot slot info.
+    /// </summary>
+    public class SnapshotSlotInfo
+    {
+        /// <summary>
+        /// The highest full snapshot slot.
+        /// </summary>
+        public ulong Full { get; set; }
+
+        /// <summary>
+        /// The highest incremental snapshot slot based on <see cref="Full"/>.
+        /// </summary>
+        public ulong? Incremental { get; set; }
+    }
+}

--- a/src/Solnet.Rpc/SolanaRpcClient.cs
+++ b/src/Solnet.Rpc/SolanaRpcClient.cs
@@ -545,10 +545,22 @@ namespace Solnet.Rpc
                 Parameters.Create(ConfigObject.Create(HandleCommitment(commitment))));
         }
 
-
         /// <inheritdoc cref="IRpcClient.GetFees"/>
         public RequestResult<ResponseValue<FeesInfo>> GetFees(Commitment commitment = Commitment.Finalized)
             => GetFeesAsync(commitment).Result;
+        
+        /// <inheritdoc cref="IRpcClient.GetFeeForMessageAsync(string, Commitment)"/>
+        public async Task<RequestResult<ResponseValue<ulong>>> GetFeeForMessageAsync(
+            string message, Commitment commitment = Commitment.Finalized)
+        {
+            List<object> parameters = Parameters.Create(message, ConfigObject.Create(HandleCommitment(commitment)));
+            return await SendRequestAsync<ResponseValue<ulong>>("getFeeForMessage", parameters);
+        }
+
+        /// <inheritdoc cref="IRpcClient.GetFeeForMessage(string, Commitment)"/>
+        public RequestResult<ResponseValue<ulong>> GetFeeForMessage(string message,
+            Commitment commitment = Commitment.Finalized)
+            => GetFeeForMessageAsync(message, commitment).Result;
 
         /// <inheritdoc cref="IRpcClient.GetRecentBlockHashAsync"/>
         public async Task<RequestResult<ResponseValue<BlockHash>>> GetRecentBlockHashAsync(
@@ -702,6 +714,15 @@ namespace Solnet.Rpc
 
         /// <inheritdoc cref="IRpcClient.GetSnapshotSlot"/>
         public RequestResult<ulong> GetSnapshotSlot() => GetSnapshotSlotAsync().Result;
+        
+        /// <inheritdoc cref="IRpcClient.GetHighestSnapshotSlotAsync"/>
+        public async Task<RequestResult<SnapshotSlotInfo>> GetHighestSnapshotSlotAsync()
+        {
+            return await SendRequestAsync<SnapshotSlotInfo>("getHighestSnapshotSlot");
+        }
+
+        /// <inheritdoc cref="IRpcClient.GetHighestSnapshotSlot"/>
+        public RequestResult<SnapshotSlotInfo> GetHighestSnapshotSlot() => GetHighestSnapshotSlotAsync().Result;
 
         /// <inheritdoc cref="IRpcClient.GetRecentPerformanceSamplesAsync"/>
         public async Task<RequestResult<List<PerformanceSample>>> GetRecentPerformanceSamplesAsync(ulong limit = 720)

--- a/test/Solnet.Rpc.Test/Resources/Http/Fees/GetFeeForMessageRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Fees/GetFeeForMessageRequest.json
@@ -1,0 +1,1 @@
+{"method":"getFeeForMessage","params":["AQABAu\u002BOVfa66vZfLI0xdX9GcGk/\u002BU65\u002Bdox\u002BiHABM3DOSGuBUpTWpkpIQZNJOhxYNo4fHw1td28kruB5B\u002BoQEEFRI3tj0g2caCBX14VjqrxK4Daz/4WvmWxU698Okvp8lYDjAEBACNIZWxsbyBTb2xhbmEgV29ybGQsIHVzaW5nIFNvbG5ldCA6KQ=="],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/Fees/GetFeeForMessageResponse.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Fees/GetFeeForMessageResponse.json
@@ -1,0 +1,1 @@
+{"jsonrpc":"2.0","result":{"context":{"slot":132177311},"value":5000},"id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/GetHighestSnapshotSlotRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/GetHighestSnapshotSlotRequest.json
@@ -1,0 +1,1 @@
+{"method":"getHighestSnapshotSlot","jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/GetHighestSnapshotSlotResponse.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/GetHighestSnapshotSlotResponse.json
@@ -1,0 +1,8 @@
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "full": 132174097,
+    "incremental": null
+  },
+  "id": 0
+}

--- a/test/Solnet.Rpc.Test/SolanaRpcClientFeeTests.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientFeeTests.cs
@@ -73,6 +73,31 @@ namespace Solnet.Rpc.Test
 
             FinishTest(messageHandlerMock, TestnetUri);
         }
+        
+        [TestMethod]
+        public void TestGetFeeForMessage()
+        {
+            var responseData = File.ReadAllText("Resources/Http/Fees/GetFeeForMessageResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/Fees/GetFeeForMessageRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+            var result = sut.GetFeeForMessage("AQABAu\u002BOVfa66vZfLI0xdX9GcGk/\u002BU65\u002Bdox\u002BiHABM3DOSGuBUpTWpkpIQZNJOhxYNo4fHw1td28kruB5B\u002BoQEEFRI3tj0g2caCBX14VjqrxK4Daz/4WvmWxU698Okvp8lYDjAEBACNIZWxsbyBTb2xhbmEgV29ybGQsIHVzaW5nIFNvbG5ldCA6KQ==");
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(132177311UL, result.Result.Context.Slot);
+            Assert.AreEqual(5000UL, result.Result.Value);
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
 
         [TestMethod]
         public void TestGetFeesConfirmed()

--- a/test/Solnet.Rpc.Test/SolanaRpcClientTest.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcClientTest.cs
@@ -628,6 +628,32 @@ namespace Solnet.Rpc.Test
 
             FinishTest(messageHandlerMock, TestnetUri);
         }
+        
+        [TestMethod]
+        public void TestGetHighestSnapshotSlot()
+        {
+            var responseData = File.ReadAllText("Resources/Http/GetHighestSnapshotSlotResponse.json");
+            var requestData = File.ReadAllText("Resources/Http/GetHighestSnapshotSlotRequest.json");
+            var sentMessage = string.Empty;
+            var messageHandlerMock = SetupTest(
+                (s => sentMessage = s), responseData);
+
+            var httpClient = new HttpClient(messageHandlerMock.Object)
+            {
+                BaseAddress = TestnetUri,
+            };
+
+            var sut = new SolanaRpcClient(TestnetUrl, null, httpClient);
+            var result = sut.GetHighestSnapshotSlot();
+
+            Assert.AreEqual(requestData, sentMessage);
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.WasSuccessful);
+            Assert.AreEqual(132174097UL, result.Result.Full);
+            Assert.IsNull(result.Result.Incremental);
+
+            FinishTest(messageHandlerMock, TestnetUri);
+        }
 
         [TestMethod]
         public void TestGetSupply()

--- a/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
+++ b/test/Solnet.Rpc.Test/Solnet.Rpc.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -129,16 +129,28 @@
     <None Update="Resources\Http\Blocks\IsBlockhashValidRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Resources\Http\Blocks\GetLatestBlockhashRequest.json">
+    <None Update="Resources\Http\Blocks\IsBlockhashValidResponse.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Resources\Http\Blocks\IsBlockhashValidResponse.json">
+    <None Update="Resources\Http\Blocks\GetLatestBlockhashRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\Http\Blocks\GetLatestBlockhashResponse.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\Http\StringErrorResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Http\Fees\GetFeeForMessageRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Http\Fees\GetFeeForMessageResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Http\GetHighestSnapshotSlotRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Http\GetHighestSnapshotSlotResponse.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\Http\GetProgramAccountsResponse-Fail-410.json">


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes |  #353  |

## Problem

_What problem are you trying to solve?_

Two missing methods from solana-core v1.9, see #353 

## Solution

_How did you solve the problem?_

Implemented `getFeeForMessage` and `getHighestSnapshotSlot`