### PR TITLE
Instruction decoder bug fix

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>6.0.10</Version>
+    <Version>6.0.11</Version>
     <Copyright>Copyright 2022 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready/| Bug | No | [Link](<Issue link here>) |

## Problem

Crash on instruction decoding.


## Solution

Missing nullcheck on decoding instructions without inner instructions.
