### PR TITLE
PublicKey constructor will quietly accept invalid inputs

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>6.0.13</Version>
+    <Version>6.0.14</Version>
     <Copyright>Copyright 2022 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Wallet/Utilities/Base58Encoder.cs
+++ b/src/Solnet.Wallet/Utilities/Base58Encoder.cs
@@ -39,17 +39,6 @@ namespace Solnet.Wallet.Utilities
             -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
             -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
         };
-        /// <summary>
-        /// Fast check if the string to know if base58 str
-        /// </summary>
-        /// <param name="str"></param>
-        /// <returns></returns>
-        public bool IsMaybeEncoded(string str)
-        {
-            bool maybeB58 = str.All(t => ((IList)PszBase58).Contains(t));
-
-            return maybeB58 && str.Length > 0;
-        }
 
         /// <summary>
         /// Encode the data.

--- a/src/Solnet.Wallet/Utilities/Base58Encoder.cs
+++ b/src/Solnet.Wallet/Utilities/Base58Encoder.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Solnet.Wallet.Utilities
@@ -15,6 +16,7 @@ namespace Solnet.Wallet.Utilities
         /// The base58 characters.
         /// </summary>
         private static readonly char[] PszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz".ToCharArray();
+        private static readonly Dictionary<char, bool> Validator = PszBase58.ToDictionary(x => x, x => true);
 
         /// <summary>
         /// 
@@ -170,5 +172,23 @@ namespace Solnet.Wallet.Utilities
                 vch[i2++] = b256[it2++];
             return vch;
         }
+
+
+        /// <summary>
+        /// Strict validation with no whitespace allowed
+        /// </summary>
+        /// <param name="value">Base58 string data</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static bool IsValidWithoutWhitespace(string value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            for (var ix = 0; ix < value.Length; ix++)
+                if (!Validator.ContainsKey(value[ix]))
+                    return false;
+            return true;
+        }
+
     }
+
 }

--- a/test/Solnet.Extensions.Test/TokenWalletTest.cs
+++ b/test/Solnet.Extensions.Test/TokenWalletTest.cs
@@ -284,7 +284,7 @@ namespace Solnet.Extensions.Test
             Assert.IsFalse(testTokenAccount.IsAssociatedTokenAccount);
 
             // trigger send to bogus target wallet
-            var targetOwner = "FAILzxtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5";
+            var targetOwner = "BADxzxtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5";
             wallet.Send(testTokenAccount, 1M, targetOwner, signer.PublicKey, builder => builder.Build(signer));
 
         }

--- a/test/Solnet.Wallet.Test/KeysTest.cs
+++ b/test/Solnet.Wallet.Test/KeysTest.cs
@@ -294,6 +294,8 @@ namespace Solnet.Wallet.Test
         public void TestIsValid()
         {
             Assert.IsTrue(PublicKey.IsValid("GUs5qLUfsEHkcMB9T38vjr18ypEhRuNWiePW2LoK4E3K"));
+            Assert.IsFalse(PublicKey.IsValid("GUs5qLUfsEHkcMB9T38vj*18ypEhRuNWiePW2LoK4E3K"));
+            Assert.IsFalse(PublicKey.IsValid("GUs5qLUfsEHkcMB9T38vjr18ypEhRuNWiePW2LoK4E3K "));
         }
 
         [TestMethod]
@@ -331,6 +333,7 @@ namespace Solnet.Wallet.Test
         public void TestIsValid_Empty_False()
         {
             Assert.IsFalse(PublicKey.IsValid(""));
+            Assert.IsFalse(PublicKey.IsValid("  "));
         }
 
         [TestMethod]
@@ -338,5 +341,20 @@ namespace Solnet.Wallet.Test
         {
             Assert.IsFalse(PublicKey.IsValid("lllllll"));
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestCreateBadPublicKeyFatal_1()
+        {
+            _ = new PublicKey("GUs5qLUfsEHkcMB9T38vjr18ypEhRuNWiePW2LoK4E3K ");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestCreateBadPublicKeyFatal_2()
+        {
+            _ = new PublicKey("GUs5qLU&sEHkcMB9T38vjr18ypEhRuNWiePW2LoK4E3K");
+        }
+
     }
 }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | 
| :---: | :---: | :---: | 
| Ready | Bugfix | Yes | 

## Problem
Encountered the error `invalid transaction: Transaction failed to sanitize accounts offsets correctly` when submiting a Serum SettleFunds command. Managed to pinpoint the root cause of the problem being a rouge space on the end of a public key string constant. Removing this space resolved the issue - this must cause some internal side-effect near the `TransactionBuilder`.

Further investigation found that PublicKey constructor would silently accept all manner of shenanigans. 
Also found that `PublicKey.IsValid` implementation relies on `Base58Encoder` validation logic that would accept whitespace.

## Solution
Added a `FastCheck` internal method to `PublicKey` and added calls to it from constructor and `IsValid`.
Added and modified a few tests.

## Deploy Notes
This is potentially a breaking change to any client apps that accept public keys that include whitespace before or after and pass them directly to the constructor. On balance, I believe this enhancement will prevent more problems than it will cause.
