### PR TITLE
Account ordering now matches web3.js

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solnet</Product>
-    <Version>6.0.14</Version>
+    <Version>6.1.0</Version>
     <Copyright>Copyright 2022 &#169; Solnet</Copyright>
     <Authors>blockmountain</Authors>
     <PublisherName>blockmountain</PublisherName>

--- a/src/Solnet.Rpc/Models/AccountKeysList.cs
+++ b/src/Solnet.Rpc/Models/AccountKeysList.cs
@@ -21,30 +21,23 @@ namespace Solnet.Rpc.Models
         {
             get
             {
-                List<AccountMeta> res = new(_accounts.Count);
-                for (int i = 0; i < _accounts.Count; i++)
-                {
-                    if (_accounts[i].IsSigner)
-                    {
-                        res.Add(_accounts[i]);
-                    }
-                }
+                List<AccountMeta> res = _accounts.Select(acc => acc).ToList();
 
-                for (int i = 0; i < _accounts.Count; i++)
+                res.Sort((x, y) =>
                 {
-                    if (!_accounts[i].IsSigner && _accounts[i].IsWritable)
+                    if (x.IsSigner != y.IsSigner)
                     {
-                        res.Add(_accounts[i]);
+                        // Signers always come before non-signers
+                        return x.IsSigner ? -1 : 1;
                     }
-                }
-
-                for (int i = 0; i < _accounts.Count; i++)
-                {
-                    if (!_accounts[i].IsSigner && !_accounts[i].IsWritable)
+                    if (x.IsWritable != y.IsWritable)
                     {
-                        res.Add(_accounts[i]);
+                        // Writable accounts always come before read-only accounts
+                        return x.IsWritable ? -1 : 1;
                     }
-                }
+                    // Otherwise, sort by pubkey, stringwise.
+                    return x.PublicKey.CompareTo(y.PublicKey);
+                });
 
                 return res;
             }

--- a/test/Solnet.Rpc.Test/TransactionBuilderTest.cs
+++ b/test/Solnet.Rpc.Test/TransactionBuilderTest.cs
@@ -34,18 +34,19 @@ namespace Solnet.Rpc.Test
             "bnmzhen0yUOsH2zbbgICAgABDAIAAACAlpgAAAAAAAMBABVIZWxsbyBmcm9tIFNvbC5OZXQgOik=";
 
         private const string ExpectedTransactionHashCreateInitializeAndMintTo =
-            "A5X22for3AxcX09IKX5Cbrpvv4k/1TcdTY2wf6vkq7Wcb/3fwMjA0vCshKkBG0EXQM2oKanIaQilKC/L" +
-            "KLmTYwc2yOVXu0TZCGwraCrxf4Pr8KpvTZZcUz/s4sls3VzGRqQmIhR3nXBR/O3\u002B4ZdICd8hYXb" +
-            "USqUBE\u002B4qCwpbC7gLlVo1ErARFL9csoTPvxA3/00wTxbs01sXlAH5t\u002ByAiwlan7B24Za3d" +
-            "CYydaczAOenGVU0nxBrz/gdFZgCJArZAAMABAdHaauXIEuoP7DK7hf3ho8eB05SFYGg2J2UN52qZbcXs" +
-            "k\u002BnIqdN4P6YFyTS64cak6Wd2hx9Qsbwf4gfPc5VPJvFTT4lvYz77q8imSqvzO/5qiFW9tKqfO4l5F" +
-            "KhFh6lZQsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAan1RcZLFxRIYzJTD1K8X9Y2u4Im6H9" +
-            "ROPb2YoAAAAABt324ddloZPZy\u002BFGzut5rBy0he1fWzeROoz1hX7/AKkFSlNQ\u002BF3IgtYUpVZye" +
-            "Iopbd8eq6vQpgZ4iEky9O72oOD/Y3arpTMrvjv2uP0ZD3LVkDTmRAfOpQ603IYXOGjCBgMCAAE0AAAAAGBN" +
-            "FgAAAAAAUgAAAAAAAAAG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQUCAQRDAAJHaauXIEuoP7DK" +
-            "7hf3ho8eB05SFYGg2J2UN52qZbcXsgFHaauXIEuoP7DK7hf3ho8eB05SFYGg2J2UN52qZbcXsgMCAAI0AAAA" +
-            "APAdHwAAAAAApQAAAAAAAAAG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQUEAgEABAEBBQMBAgA" +
-            "JB6hhAAAAAAAABgECEkhlbGxvIGZyb20gU29sLk5ldA==";
+            "A056qhN8bf9baCZ6SwzUlM6ge4X19TzoKANpDjg9CUGQTvIOYu27MvTcscgGov0aMkuiM9N8g" +
+            "1D2bMJSvYBpWwi2IP+9oPzCj4b0AWm6uLxLv+JrMwVB8gJBYf4JtXotWDY504QIm9IqEemgUK" +
+            "vWkb+9dNatYsR3d9xcqxQ14mAEAq147oIAH+FQbHj2PhdP61KXqTN7T0EclKQMJLyhkqeyREF" +
+            "10Ttg99bcwTuXMxfR5rstI/kg/0Cagr/Ua+SoAQMABAdHaauXIEuoP7DK7hf3ho8eB05SFYGg" +
+            "2J2UN52qZbcXsk0+Jb2M++6vIpkqr8zv+aohVvbSqnzuJeRSoRYepWULT6cip03g/pgXJNLrh" +
+            "xqTpZ3aHH1CxvB/iB89zlU8m8UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVKU1" +
+            "D4XciC1hSlVnJ4iilt3x6rq9CmBniISTL07vagBqfVFxksXFEhjMlMPUrxf1ja7gibof1E49v" +
+            "ZigAAAAAG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqeD/Y3arpTMrvjv2uP0ZD3LV" +
+            "kDTmRAfOpQ603IYXOGjCBgMCAAI0AAAAAGBNFgAAAAAAUgAAAAAAAAAG3fbh12Whk9nL4UbO6" +
+            "3msHLSF7V9bN5E6jPWFfv8AqQYCAgVDAAJHaauXIEuoP7DK7hf3ho8eB05SFYGg2J2UN52qZb" +
+            "cXsgFHaauXIEuoP7DK7hf3ho8eB05SFYGg2J2UN52qZbcXsgMCAAE0AAAAAPAdHwAAAAAApQA" +
+            "AAAAAAAAG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQYEAQIABQEBBgMCAQAJB6hh" +
+            "AAAAAAAABAEBEkhlbGxvIGZyb20gU29sLk5ldA==";
 
         private const string Nonce = "2S1kjspXLPs6jpNVXQfNMqZzzSrKLbGdr9Fxap5h1DLN";
 
@@ -178,6 +179,11 @@ namespace Solnet.Rpc.Test
                     ownerAccount))
                 .AddInstruction(MemoProgram.NewMemo(initialAccount, "Hello from Sol.Net"))
                 .Build(new List<Account> { ownerAccount, mintAccount, initialAccount });
+
+            var tx2 = Transaction.Deserialize(tx);
+            var msg = tx2.CompileMessage();
+
+            Assert.IsTrue(tx2.Signatures[0].PublicKey.Verify(msg, tx2.Signatures[0].Signature));
 
             Assert.AreEqual(ExpectedTransactionHashCreateInitializeAndMintTo, Convert.ToBase64String(tx));
         }

--- a/test/Solnet.Rpc.Test/TransactionTest.cs
+++ b/test/Solnet.Rpc.Test/TransactionTest.cs
@@ -78,23 +78,6 @@ namespace Solnet.Rpc.Test
 
         };
 
-        private static readonly byte[] Base64MessageBytes =
-        {
-            2, 0, 4, 6, 103, 132, 83, 145, 168, 194, 85, 123, 82, 13, 216, 210, 8, 202, 191, 237, 245, 126, 242,
-            121, 138, 175, 133, 11, 234, 99, 249, 185, 73, 124, 75, 186, 215, 144, 108, 229, 90, 58, 154, 117, 217,
-            94, 248, 119, 229, 66, 230, 78, 27, 114, 135, 1, 252, 199, 48, 228, 240, 40, 6, 168, 29, 72, 75, 41,
-            139, 31, 75, 78, 123, 162, 191, 215, 73, 252, 141, 86, 38, 131, 208, 130, 205, 241, 73, 237, 15, 207,
-            180, 165, 130, 89, 152, 200, 252, 194, 65, 137, 6, 167, 213, 23, 25, 44, 92, 81, 33, 140, 201, 76, 61,
-            74, 241, 127, 88, 218, 238, 8, 155, 161, 253, 68, 227, 219, 217, 138, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 221, 246, 225, 215, 101,
-            161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133,
-            126, 255, 0, 169, 226, 31, 67, 54, 250, 17, 27, 252, 75, 96, 42, 63, 121, 41, 168, 87, 181, 174, 19,
-            162, 241, 175, 42, 248, 122, 1, 229, 159, 248, 89, 71, 226, 2, 4, 2, 0, 1, 52, 0, 0, 0, 0, 240, 29, 31,
-            0, 0, 0, 0, 0, 165, 0, 0, 0, 0, 0, 0, 0, 6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206,
-            235, 121, 172, 28, 180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169, 5, 4, 1, 2, 0,
-            3, 1, 1
-        };
-
         private const string InvalidBase64Transaction =
             "AQ0S4USBAYBAAIFR2mrlyBLqD+wyu4X94aPHgdOUhWBoNidlDedqmW3F7KE3M6r5DRwldquwlqOuXDDOWZagXmbHnAU3w5Dg44kot" +
             "/05ThW8wBKVjo4jhGCcZM9AYh+8xbirWxK1GhRx3i0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGp9UXGSxWjuCKhF9" +
@@ -361,10 +344,6 @@ namespace Solnet.Rpc.Test
             tx.AddSignature(initialAccount.PublicKey, initialAccount.Sign(txBytes));
 
             byte[] serializedBytes = tx.Serialize();
-
-            var msg = tx.CompileMessage();
-
-            
             
             CollectionAssert.AreEqual(CraftTransactionBytes, serializedBytes);
         }

--- a/test/Solnet.Rpc.Test/TransactionTest.cs
+++ b/test/Solnet.Rpc.Test/TransactionTest.cs
@@ -47,35 +47,35 @@ namespace Solnet.Rpc.Test
 
         private static byte[] CraftTransactionBytes =
         {
-            3, 39, 133, 112, 132, 32, 126, 228, 126, 162, 203, 140, 203, 161, 134, 191, 186, 195, 40, 66, 175, 125,
-            129, 149, 141, 94, 83, 223, 88, 37, 237, 88, 160, 147, 101, 191, 50, 230, 58, 245, 82, 5, 23, 44, 122,
-            79, 224, 190, 225, 206, 132, 15, 138, 137, 143, 17, 148, 250, 111, 164, 35, 208, 194, 9, 2, 18, 107, 39,
-            21, 58, 29, 82, 145, 91, 70, 215, 39, 5, 18, 104, 69, 228, 20, 179, 207, 44, 0, 143, 140, 164, 142, 97,
-            61, 34, 203, 104, 86, 167, 132, 38, 160, 245, 146, 209, 198, 46, 113, 162, 37, 33, 79, 154, 9, 84, 215,
-            138, 178, 241, 209, 128, 108, 251, 109, 233, 117, 140, 30, 19, 1, 10, 137, 215, 161, 51, 158, 235, 5,
-            105, 100, 174, 155, 117, 233, 203, 245, 129, 157, 103, 245, 180, 60, 238, 83, 84, 195, 60, 30, 27, 245,
-            172, 26, 8, 40, 74, 196, 187, 184, 163, 152, 209, 104, 65, 214, 173, 26, 102, 193, 86, 155, 75, 39, 49,
-            253, 178, 64, 41, 155, 43, 230, 220, 207, 157, 0, 3, 0, 4, 7, 71, 105, 171, 151, 32, 75, 168, 63, 176,
-            202, 238, 23, 247, 134, 143, 30, 7, 78, 82, 21, 129, 160, 216, 157, 148, 55, 157, 170, 101, 183, 23,
-            178, 215, 137, 216, 107, 200, 181, 124, 152, 190, 73, 13, 182, 204, 46, 141, 8, 127, 222, 225, 79, 199,
-            135, 152, 53, 129, 239, 152, 82, 141, 143, 98, 133, 205, 251, 13, 211, 102, 148, 169, 147, 62, 156, 122,
-            35, 98, 20, 157, 88, 150, 56, 27, 74, 223, 168, 25, 163, 120, 95, 11, 3, 42, 184, 239, 59, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 167, 213, 23, 25,
-            44, 92, 81, 33, 140, 201, 76, 61, 74, 241, 127, 88, 218, 238, 8, 155, 161, 253, 68, 227, 219, 217, 138,
-            0, 0, 0, 0, 6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133,
-            237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169, 5, 74, 83, 80, 248, 93, 200, 130, 214, 20,
-            165, 86, 114, 120, 138, 41, 109, 223, 30, 171, 171, 208, 166, 6, 120, 136, 73, 50, 244, 238, 246, 160,
-            206, 78, 169, 189, 0, 235, 196, 10, 163, 190, 178, 243, 194, 80, 1, 89, 248, 166, 252, 150, 61, 65, 187,
-            142, 133, 205, 198, 253, 19, 241, 15, 248, 6, 3, 2, 0, 1, 52, 0, 0, 0, 0, 96, 77, 22, 0, 0, 0, 0, 0, 82,
-            0, 0, 0, 0, 0, 0, 0, 6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28,
-            180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169, 5, 2, 1, 4, 67, 0, 2, 71, 105, 171,
-            151, 32, 75, 168, 63, 176, 202, 238, 23, 247, 134, 143, 30, 7, 78, 82, 21, 129, 160, 216, 157, 148, 55,
-            157, 170, 101, 183, 23, 178, 1, 71, 105, 171, 151, 32, 75, 168, 63, 176, 202, 238, 23, 247, 134, 143,
-            30, 7, 78, 82, 21, 129, 160, 216, 157, 148, 55, 157, 170, 101, 183, 23, 178, 3, 2, 0, 2, 52, 0, 0, 0, 0,
-            240, 29, 31, 0, 0, 0, 0, 0, 165, 0, 0, 0, 0, 0, 0, 0, 6, 221, 246, 225, 215, 101, 161, 147, 217, 203,
-            225, 70, 206, 235, 121, 172, 28, 180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169, 5,
-            4, 2, 1, 0, 4, 1, 1, 5, 3, 1, 2, 0, 9, 7, 64, 66, 15, 0, 0, 0, 0, 0, 6, 1, 2, 18, 72, 101, 108, 108,
-            111, 32, 102, 114, 111, 109, 32, 83, 111, 108, 46, 78, 101, 116
+            3, 230, 155, 244, 7, 138, 48, 69, 134, 17, 31, 188, 153, 121, 114, 199, 185, 236, 232, 115, 176, 139, 
+            150, 72, 167, 98, 110, 93, 170, 237, 95, 49, 204, 1, 100, 43, 189, 169, 146, 230, 50, 24, 217, 145, 178, 
+            114, 72, 186, 85, 3, 184, 2, 122, 27, 231, 100, 58, 113, 159, 65, 161, 136, 77, 147, 5, 232, 59, 124, 
+            162, 191, 129, 233, 0, 130, 46, 252, 112, 3, 165, 31, 143, 210, 206, 153, 164, 16, 118, 173, 237, 141, 
+            185, 150, 235, 248, 205, 254, 173, 217, 139, 60, 16, 35, 126, 75, 111, 138, 38, 150, 13, 120, 180, 170, 
+            187, 63, 131, 238, 189, 66, 63, 145, 33, 121, 136, 174, 102, 31, 66, 104, 13, 213, 251, 200, 222, 131, 69, 
+            208, 88, 110, 109, 2, 115, 201, 248, 97, 158, 253, 222, 194, 201, 191, 121, 216, 69, 235, 79, 220, 19, 22, 
+            172, 232, 229, 3, 76, 93, 12, 158, 231, 28, 107, 148, 8, 177, 6, 237, 80, 176, 106, 121, 65, 72, 91, 223, 
+            34, 14, 213, 247, 191, 254, 72, 195, 99, 4, 13, 3, 0, 4, 7, 71, 105, 171, 151, 32, 75, 168, 63, 176, 202, 
+            238, 23, 247, 134, 143, 30, 7, 78, 82, 21, 129, 160, 216, 157, 148, 55, 157, 170, 101, 183, 23, 178, 205, 
+            251, 13, 211, 102, 148, 169, 147, 62, 156, 122, 35, 98, 20, 157, 88, 150, 56, 27, 74, 223, 168, 25, 163, 
+            120, 95, 11, 3, 42, 184, 239, 59, 215, 137, 216, 107, 200, 181, 124, 152, 190, 73, 13, 182, 204, 46, 141, 
+            8, 127, 222, 225, 79, 199, 135, 152, 53, 129, 239, 152, 82, 141, 143, 98, 133, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 74, 83, 80, 248, 93, 200, 130, 214, 
+            20, 165, 86, 114, 120, 138, 41, 109, 223, 30, 171, 171, 208, 166, 6, 120, 136, 73, 50, 244, 238, 246, 160, 
+            6, 167, 213, 23, 25, 44, 92, 81, 33, 140, 201, 76, 61, 74, 241, 127, 88, 218, 238, 8, 155, 161, 253, 68, 227, 
+            219, 217, 138, 0, 0, 0, 0, 6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 
+            180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169, 206, 78, 169, 189, 0, 235, 196, 10, 163, 
+            190, 178, 243, 194, 80, 1, 89, 248, 166, 252, 150, 61, 65, 187, 142, 133, 205, 198, 253, 19, 241, 15, 248, 6, 
+            3, 2, 0, 2, 52, 0, 0, 0, 0, 96, 77, 22, 0, 0, 0, 0, 0, 82, 0, 0, 0, 0, 0, 0, 0, 6, 221, 246, 225, 215, 101, 
+            161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 
+            255, 0, 169, 6, 2, 2, 5, 67, 0, 2, 71, 105, 171, 151, 32, 75, 168, 63, 176, 202, 238, 23, 247, 134, 143, 30, 
+            7, 78, 82, 21, 129, 160, 216, 157, 148, 55, 157, 170, 101, 183, 23, 178, 1, 71, 105, 171, 151, 32, 75, 168, 
+            63, 176, 202, 238, 23, 247, 134, 143, 30, 7, 78, 82, 21, 129, 160, 216, 157, 148, 55, 157, 170, 101, 183, 
+            23, 178, 3, 2, 0, 1, 52, 0, 0, 0, 0, 240, 29, 31, 0, 0, 0, 0, 0, 165, 0, 0, 0, 0, 0, 0, 0, 6, 221, 246, 225, 
+            215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 
+            133, 126, 255, 0, 169, 6, 4, 1, 2, 0, 5, 1, 1, 6, 3, 2, 1, 0, 9, 7, 64, 66, 15, 0, 0, 0, 0, 0, 4, 1, 1, 18, 
+            72, 101, 108, 108, 111, 32, 102, 114, 111, 109, 32, 83, 111, 108, 46, 78, 101, 116
+
         };
 
         private static readonly byte[] Base64MessageBytes =
@@ -107,13 +107,13 @@ namespace Solnet.Rpc.Test
             "AAABVED1IAMQCS8bANVPk3JwnUUDkIwVnTMaKQLYx1FS5TAgMDAgQABAQAAAADAgABDAIAAAAAypo7AAAAAA==";
 
         private const string Base64Message =
-            "AwAEB0dpq5cgS6g/sMruF/eGjx4HTlIVgaDYnZQ3napltxey14nYa8i1fJi+SQ22zC6NCH/e4U/Hh5g1ge+YUo2PYoXN+w3TZpSp" +
-            "kz6ceiNiFJ1YljgbSt+oGaN4XwsDKrjvOwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABqfVFxksXFEhjMlMPUrxf1j" +
-            "a7gibof1E49vZigAAAAAG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQVKU1D4XciC1hSlVnJ4iilt3x6rq9CmBniIST" +
-            "L07vag08KSJSZSZjfxTEKmUU+9fVdZry+IheZu/BJgfwylBe0GAwIAATQAAAAAYE0WAAAAAABSAAAAAAAAAAbd9uHXZaGT2cvh" +
-            "Rs7reawctIXtX1s3kTqM9YV+/wCpBQIBBEMAAkdpq5cgS6g/sMruF/eGjx4HTlIVgaDYnZQ3napltxeyAUdpq5cgS6g/sMruF/" +
-            "eGjx4HTlIVgaDYnZQ3napltxeyAwIAAjQAAAAA8B0fAAAAAAClAAAAAAAAAAbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+" +
-            "/wCpBQQCAQAEAQEFAwECAAkHQEIPAAAAAAAGAQISSGVsbG8gZnJvbSBTb2wuTmV0";
+            "AwAEB0dpq5cgS6g/sMruF/eGjx4HTlIVgaDYnZQ3napltxeyzfsN02aUqZM+nHojYhSdWJY4G0rfqBmjeF8LAyq47zvXidhry" +
+            "LV8mL5JDbbMLo0If97hT8eHmDWB75hSjY9ihQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUpTUPhdyILWFKVWcn" +
+            "iKKW3fHqur0KYGeIhJMvTu9qAGp9UXGSxcUSGMyUw9SvF/WNruCJuh/UTj29mKAAAAAAbd9uHXZaGT2cvhRs7reawctIXtX1s" +
+            "3kTqM9YV+/wCpzk6pvQDrxAqjvrLzwlABWfim/JY9QbuOhc3G/RPxD/gGAwIAAjQAAAAAYE0WAAAAAABSAAAAAAAAAAbd9uHX" +
+            "ZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpBgICBUMAAkdpq5cgS6g/sMruF/eGjx4HTlIVgaDYnZQ3napltxeyAUdpq5cgS" +
+            "6g/sMruF/eGjx4HTlIVgaDYnZQ3napltxeyAwIAATQAAAAA8B0fAAAAAAClAAAAAAAAAAbd9uHXZaGT2cvhRs7reawctIXtX1" +
+            "s3kTqM9YV+/wCpBgQBAgAFAQEGAwIBAAkHQEIPAAAAAAAEAQESSGVsbG8gZnJvbSBTb2wuTmV0";
 
         private const string PopulatedBase64MessageTx =
             "AywGaWtisQ1ssPzJjYz4MfsQYxFabAmqBN5ikzhLIVyI/78SFuYDjqcppmaVXUT7e5G0ibfcw566OrktXauH+wjrzZ7AK9Ct0hm" +
@@ -195,14 +195,14 @@ namespace Solnet.Rpc.Test
         {
             Transaction tx = Transaction.Populate(Base64Message, new List<byte[]>()
             {
-                Encoders.Base58.DecodeData("t3zuom7qpa4XQ2WxDTZPFcWjhPuB3uKJDzKSsnawyoHohFrgmfGWWPwB8VkZSMexTVWPQLd4fWLmRdt8CAW49yH"),
-                Encoders.Base58.DecodeData("5iSSyXbaYgBB1QUuHip6M3syLz4kg8PYmX6233XbJz7VJoTeTgRWThKvoXrTr638eXK4kEYo7ejMT1axmW8PvRnr"),
-                Encoders.Base58.DecodeData("3GaoLXHf563Si8jypoBYhNP7Mx8winbcgHcNxByuK6tnndKVGUQ4ByqTnM5Y3thsmgX87W16Yw5cb6cobwDW7ucC"),
+                Encoders.Base58.DecodeData("5cR7atqKv6zc73VFCK5iF58ytoaGMa9fFrY1JG95yn5QyyFPDxCtBmuBLvpZXF5o79YZ1phSoDD4ELqnJy468Ktg"),
+                Encoders.Base58.DecodeData("5eJHTqGiAq4AGdJDT35A8zxJv9FjYfFd4YM1KivWYxxSVUmc9f5iFLbGbJiup7EhuMuYRHNXuV12BbWe1bcivLKN"),
+                Encoders.Base58.DecodeData("5H8vKk6PGJKJxYxFfRkUnNwwJv9HaaZzmPfBSxJkvMpAgknm3JakR77WchVfHMTCHdG9mCWULjc8jEvHJb7wwXQG"),
             });
 
             byte[] txBytes = tx.Serialize();
 
-            Assert.AreEqual(PopulatedBase64MessageTx, Convert.ToBase64String(txBytes));
+            CollectionAssert.AreEqual(CraftTransactionBytes, txBytes);
         }
 
         [TestMethod]
@@ -362,6 +362,10 @@ namespace Solnet.Rpc.Test
 
             byte[] serializedBytes = tx.Serialize();
 
+            var msg = tx.CompileMessage();
+
+            
+            
             CollectionAssert.AreEqual(CraftTransactionBytes, serializedBytes);
         }
     }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug/Refactor |  Closes #397 |

## Problem

Partial signing is incompatible with web3.js


## Solution

Fixed account ordering to match web3.js. 

Minor version bump instead of patch.