### PR TITLE
Fix wrong function names in code doc

### DIFF
--- a/src/Solnet.Rpc/IRpcClient.cs
+++ b/src/Solnet.Rpc/IRpcClient.cs
@@ -715,7 +715,7 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
-        [Obsolete("DEPRECATED: Please use GetLatestBlockhashAsync instead. This method is expected to be removed in solana-core v2.0")]
+        [Obsolete("DEPRECATED: Please use GetLatestBlockHashAsync instead. This method is expected to be removed in solana-core v2.0")]
         Task<RequestResult<ResponseValue<BlockHash>>> GetRecentBlockHashAsync(Commitment commitment = Commitment.Finalized);
 
         /// <summary>
@@ -723,7 +723,7 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        [Obsolete("DEPRECATED: Please use GetLatestBlockhash instead. This method is expected to be removed in solana-core v2.0")]
+        [Obsolete("DEPRECATED: Please use GetLatestBlockHash instead. This method is expected to be removed in solana-core v2.0")]
         RequestResult<ResponseValue<BlockHash>> GetRecentBlockHash(Commitment commitment = Commitment.Finalized);
 
         /// <summary>


### PR DESCRIPTION
> ⚠️ NOTE: Use notes like this to emphasize something important about the PR.
>  
>  This could include other PRs this PR is built on top of; API breaking changes; reasons for why the PR is on hold; or anything else you would like to draw attention to.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No | - |

## Problem

The code docs in deprecated parts put wrong function names, which could misguide users.


## Solution

Fixed it by the correct function names.
