### PR TITLE
Add optionnal parameter maxSupportedTransactionVersion to support ver…

### DIFF
--- a/src/Solnet.Extensions/Models/TokenWallet/TokenQuantity.cs
+++ b/src/Solnet.Extensions/Models/TokenWallet/TokenQuantity.cs
@@ -74,9 +74,9 @@ namespace Solnet.Extensions
         public override string ToString()
         {
             if (Symbol == TokenName)
-                return $"{QuantityDecimal} {Symbol}";
+                return $"{QuantityDecimal.ToString(System.Globalization.CultureInfo.InvariantCulture)} {Symbol}";
             else
-                return $"{QuantityDecimal} {Symbol} ({TokenName})";
+                return $"{QuantityDecimal.ToString(System.Globalization.CultureInfo.InvariantCulture)} {Symbol} ({TokenName})";
         }
 
         /// <summary>

--- a/src/Solnet.Rpc/IRpcClient.cs
+++ b/src/Solnet.Rpc/IRpcClient.cs
@@ -129,10 +129,11 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="slot">The slot.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <param name="maxSupportedTransactionVersion">max supported transaction version</param>
         /// <param name="transactionDetails">The level of transaction detail to return, see <see cref="TransactionDetailsFilterType"/>.</param>
         /// <param name="blockRewards">Whether to populate the <c>rewards</c> array, the default includes rewards.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
-        Task<RequestResult<BlockInfo>> GetBlockAsync(ulong slot, Commitment commitment = Commitment.Finalized,
+        Task<RequestResult<BlockInfo>> GetBlockAsync(ulong slot, Commitment commitment = Commitment.Finalized, int maxSupportedTransactionVersion = 0,
             TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, bool blockRewards = false);
 
         /// <summary>
@@ -152,12 +153,14 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="slot">The slot.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <param name="maxSupportedTransactionVersion">max supported transaction version</param>
         /// <param name="transactionDetails">The level of transaction detail to return, see <see cref="TransactionDetailsFilterType"/>.</param>
         /// <param name="blockRewards">Whether to populate the <c>rewards</c> array, the default includes rewards.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         [Obsolete("Please use GetBlockAsync whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
         Task<RequestResult<BlockInfo>> GetConfirmedBlockAsync(ulong slot, Commitment commitment = Commitment.Finalized,
-            TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, bool blockRewards = false);
+            int maxSupportedTransactionVersion = 0, TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, 
+            bool blockRewards = false);
 
         /// <summary>
         /// Returns identity and transaction information about a block in the ledger.
@@ -176,11 +179,13 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="slot">The slot.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <param name="maxSupportedTransactionVersion">max supported transaction version</param>
         /// <param name="transactionDetails">The level of transaction detail to return, see <see cref="TransactionDetailsFilterType"/>.</param>
         /// <param name="blockRewards">Whether to populate the <c>rewards</c> array, the default includes rewards.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         RequestResult<BlockInfo> GetBlock(ulong slot, Commitment commitment = Commitment.Finalized,
-            TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, bool blockRewards = false);
+            int maxSupportedTransactionVersion = 0, TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, 
+            bool blockRewards = false);
 
         /// <summary>
         /// Returns identity and transaction information about a confirmed block in the ledger.
@@ -199,12 +204,14 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="slot">The slot.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <param name="maxSupportedTransactionVersion">max supported transaction version</param>
         /// <param name="transactionDetails">The level of transaction detail to return, see <see cref="TransactionDetailsFilterType"/>.</param>
         /// <param name="blockRewards">Whether to populate the <c>rewards</c> array, the default includes rewards.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         [Obsolete("Please use GetBlock whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
         RequestResult<BlockInfo> GetConfirmedBlock(ulong slot, Commitment commitment = Commitment.Finalized,
-            TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, bool blockRewards = false);
+            int maxSupportedTransactionVersion = 0, TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, 
+            bool blockRewards = false);
 
         /// <summary>
         /// Gets the block commitment of a certain block, identified by slot.
@@ -1075,9 +1082,10 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="signature">Transaction signature as base-58 encoded string.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <param name="maxSupportedTransactionVersion">max supported transaction version</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<TransactionMetaSlotInfo>> GetTransactionAsync(string signature,
-            Commitment commitment = Commitment.Finalized);
+            Commitment commitment = Commitment.Finalized, int maxSupportedTransactionVersion = 0);
 
         /// <summary>
         /// Returns transaction details for a confirmed transaction.
@@ -1089,10 +1097,12 @@ namespace Solnet.Rpc
         /// </remarks>
         /// </summary>
         /// <param name="signature">Transaction signature as base-58 encoded string.</param>
+        /// <param name="maxSupportedTransactionVersion">max supported transaction version</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         [Obsolete("Please use GetTransactionAsync whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
-        Task<RequestResult<TransactionMetaSlotInfo>> GetConfirmedTransactionAsync(string signature, Commitment commitment = Commitment.Finalized);
+        Task<RequestResult<TransactionMetaSlotInfo>> GetConfirmedTransactionAsync(string signature, Commitment commitment = Commitment.Finalized,
+            int maxSupportedTransactionVersion = 0);
 
         /// <summary>
         /// Returns transaction details for a confirmed transaction.
@@ -1105,8 +1115,10 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="signature">Transaction signature as base-58 encoded string.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <param name="maxSupportedTransactionVersion">max supported transaction version</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<TransactionMetaSlotInfo> GetTransaction(string signature, Commitment commitment = Commitment.Finalized);
+        RequestResult<TransactionMetaSlotInfo> GetTransaction(string signature, Commitment commitment = Commitment.Finalized,
+            int maxSupportedTransactionVersion = 0);
 
         /// <summary>
         /// Returns transaction details for a confirmed transaction.
@@ -1119,9 +1131,11 @@ namespace Solnet.Rpc
         /// </summary>
         /// <param name="signature">Transaction signature as base-58 encoded string.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <param name="maxSupportedTransactionVersion">max supported transaction version</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         [Obsolete("Please use GetTransaction whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
-        RequestResult<TransactionMetaSlotInfo> GetConfirmedTransaction(string signature, Commitment commitment = Commitment.Finalized);
+        RequestResult<TransactionMetaSlotInfo> GetConfirmedTransaction(string signature, Commitment commitment = Commitment.Finalized,
+            int maxSupportedTransactionVersion = 0);
 
         /// <summary>
         /// Gets the total transaction count of the ledger.

--- a/src/Solnet.Rpc/Models/AddressLookupTableState.cs
+++ b/src/Solnet.Rpc/Models/AddressLookupTableState.cs
@@ -1,0 +1,41 @@
+using Solnet.Wallet;
+using System.Collections.Generic;
+
+namespace Solnet.Rpc.Models
+{
+    public class AddressLookupTableState
+    {
+        public long DeactivationSlot { get; set; }
+        public int LastExtendedSlot { get; set; }
+        public int LastExtendedSlowStartIndex { get ; set; }
+        public PublicKey Authority { get; set; }
+        public List<PublicKey> Addresses { get; set; }
+    }
+    
+    
+    public class AddressLookupTableAccount
+    {
+        private PublicKey _key;
+        private AddressLookupTableState _state;
+
+        public AddressLookupTableAccount(PublicKey key, AddressLookupTableState state)
+        {
+            _key = key;
+            _state = state;
+        }
+
+        public bool IsActive 
+        {
+            get 
+            {
+                return _state.DeactivationSlot == long.MaxValue;
+            }
+        }
+
+        public static AddressLookupTableState Deserialize(byte[] accountData)
+        {
+            var meta = DecodeData()
+        }
+
+    }
+}

--- a/src/Solnet.Rpc/Models/Block.cs
+++ b/src/Solnet.Rpc/Models/Block.cs
@@ -64,6 +64,12 @@ namespace Solnet.Rpc.Models
         /// Estimated block production time.
         /// </summary>
         public long? BlockTime { get; set; }
+
+        /// <summary>
+        /// Transaction version
+        /// </summary>
+        /// <value></value>
+        public object Version { get ;set; }
     }
 
 
@@ -179,6 +185,12 @@ namespace Solnet.Rpc.Models
         /// List of program instructions that will be executed in sequence and committed in one atomic transaction if all succeed.
         /// </summary>
         public InstructionInfo[] Instructions { get; set; }
+
+        /// <summary>
+        /// Addresses table lookup
+        /// </summary>
+        /// <value></value>
+        public MessageAddressTableLookup[] AddressTableLookup { get; set; }
     }
 
     /// <summary>
@@ -247,6 +259,12 @@ namespace Solnet.Rpc.Models
         /// Array of string log messages or omitted if log message recording was not yet enabled during this transaction.
         /// </summary>
         public string[] LogMessages { get; set; }
+
+        /// <summary>
+        /// Transaction loaded addresses
+        /// </summary>
+        /// <value></value>
+        public AccountKeysFromLookups LoadedAddresses { get; set; } 
     }
 
     /// <summary>
@@ -381,5 +399,123 @@ namespace Solnet.Rpc.Models
         /// The last block height at which the blockhash will be valid.
         /// </summary>
         public ulong LastValidBlockHeight { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the block info.
+    /// </summary>
+    public class BlockVersionnedInfo
+    {
+        /// <summary>
+        /// Estimated block production time.
+        /// </summary>
+        public long BlockTime { get; set; }
+
+        /// <summary>
+        /// A base-58 encoded public key representing the block hash.
+        /// </summary>
+        public string Blockhash { get; set; }
+
+        /// <summary>
+        /// A base-58 encoded public key representing the block hash of this block's parent.
+        /// <remarks>
+        /// If the parent block is no longer available due to ledger cleanup, this field will return
+        /// '11111111111111111111111111111111'
+        /// </remarks>
+        /// </summary>
+        public string PreviousBlockhash { get; set; }
+
+        /// <summary>
+        /// The slot index of this block's parent.
+        /// </summary>
+        public ulong ParentSlot { get; set; }
+
+        /// <summary>
+        /// The number of blocks beneath this block.
+        /// </summary>
+        public long? BlockHeight { get; set; }
+
+        /// <summary>
+        /// The rewards for this given block.
+        /// </summary>
+        public RewardInfo[] Rewards { get; set; }
+
+        /// <summary>
+        /// Collection of transactions and their metadata within this block.
+        /// </summary>
+        public TransactionMetaInfo[] Transactions { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the transaction, metadata and its containing slot.
+    /// </summary>
+    public class TransactionMetaSlotVersionnedInfo : TransactionMetaVersionnedInfo
+    {
+        /// <summary>
+        /// The slot this transaction was processed in.
+        /// </summary>
+        public ulong Slot { get; set; }
+
+        /// <summary>
+        /// Estimated block production time.
+        /// </summary>
+        public long? BlockTime { get; set; }
+    }
+
+
+    /// <summary>
+    /// Represents the tuple transaction and metadata.
+    /// </summary>
+    public class TransactionMetaVersionnedInfo
+    {
+        /// <summary>
+        /// The transaction information.
+        /// </summary>
+        public TransactionVersionnedInfo Transaction { get; set; }
+
+        /// <summary>
+        /// The metadata information.
+        /// </summary>
+        public TransactionVersionnedMeta Meta { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a transaction.
+    /// </summary>
+    public class TransactionVersionnedInfo
+    {
+        /// <summary>
+        /// The signatures of this transaction.
+        /// </summary>
+        public string[] Signatures { get; set; }
+
+        /// <summary>
+        /// The message contents of the transaction.
+        /// </summary>
+        public TransactionContentVersionnedInfo Message { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the contents of the trasaction.
+    /// </summary>
+    public class TransactionContentVersionnedInfo: TransactionContentInfo
+    {
+        /// <summary>
+        /// Address table lookup for transaction
+        /// </summary>
+        /// <value></value>
+        public MessageAddressTableLookup[] AddressTableLookups { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the transaction metadata.
+    /// </summary>
+    public class TransactionVersionnedMeta: TransactionMeta
+    {
+        /// <summary>
+        /// Loaded address for the tranasaction
+        /// </summary>
+        /// <value></value>
+        public AccountKeysFromLookups LoadedAddresses { get; set; }
     }
 }

--- a/src/Solnet.Rpc/Models/MessageAccountKeys.cs
+++ b/src/Solnet.Rpc/Models/MessageAccountKeys.cs
@@ -1,0 +1,55 @@
+using Solnet.Wallet;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Solnet.Rpc.Models
+{
+    /// <summary>
+    /// A wrapper around a list of <see cref="AccountMeta"/>s that takes care of deduplication and ordering according to 
+    /// the wire format specification.
+    /// </summary>
+    internal class MessageAccountKeys
+    {
+        /// <summary>
+        /// The static account metas list.
+        /// </summary>
+        private readonly List<PublicKey> _staticAccounts;
+
+        private AccountKeysFromLookups _accountKeysFromLookups;
+
+
+        internal List<PublicKey> KeySegments
+        {
+            get 
+            {
+                var segments = _staticAccounts.ToList();
+                if (_accountKeysFromLookups != null)
+                {
+                    segments.AddRange(_accountKeysFromLookups.Writables);
+                    segments.AddRange(_accountKeysFromLookups.Readonly);
+                }
+
+                return segments;
+            }
+        }
+
+        /// <summary>
+        /// Initialize the account keys list for use within transaction building.
+        /// </summary>
+        internal MessageAccountKeys(List<PublicKey> staticAccounts, AccountKeysFromLookups accountKeysFromLookups = null)
+        {
+            _staticAccounts = staticAccounts;
+            _accountKeysFromLookups = accountKeysFromLookups;
+        }
+
+        public PublicKey Get(int index)
+        {
+            if (index < KeySegments.Count)
+            {
+                return KeySegments[index];
+            }
+
+            return null;
+        }       
+    }
+}

--- a/src/Solnet.Rpc/Models/MessageV0.cs
+++ b/src/Solnet.Rpc/Models/MessageV0.cs
@@ -1,0 +1,324 @@
+using Solnet.Rpc.Utilities;
+using Solnet.Wallet;
+using Solnet.Wallet.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Solnet.Rpc.Models
+{
+    public class VersionnedMessage
+    {
+        /// <summary>
+        /// Prefix to determine the message version
+        /// </summary>
+        public static byte VersionPrefixMask = 0x7f;
+
+        private enum MessageVersion
+        {
+            Legacy = 0,
+            Versionned = 1,
+        }
+
+        private (MessageVersion type, int version) DeserializeVersion(byte prefix)
+        {
+            var maskedPrefix = prefix & VersionPrefixMask;
+
+            // if the highest bit of the prefix is not set, the message is not versioned
+            if (maskedPrefix == prefix)
+            {
+                return new (MessageVersion.Legacy, -1);
+            }
+
+            // the lower 7 bits of the prefix indicate the message version
+            return new (MessageVersion.Versionned, maskedPrefix);
+        }
+        
+                
+    }
+    
+    /// <summary>
+    /// Represents the versionned Message of a Solana <see cref="Transaction"/>.
+    /// </summary>
+    public class MessageV0
+    {
+        /// <summary>
+        /// The header of the <see cref="Message"/>.
+        /// </summary>
+        public MessageHeader Header { get; set; }
+
+        /// <summary>
+        /// The list of account <see cref="PublicKey"/>s present in the transaction.
+        /// </summary>
+        public IList<PublicKey> AccountKeys { get; set; }
+
+        /// <summary>
+        /// The list of <see cref="TransactionInstruction"/>s present in the transaction.
+        /// </summary>
+        public IList<CompiledInstruction> Instructions { get; set; }
+
+        /// <summary>
+        /// Address table lookup for the transaction
+        /// </summary>
+        /// <value></value>
+        public IList<MessageAddressTableLookup> AddressTableLookups { get; set; }
+
+        /// <summary>
+        /// The recent block hash for the transaction.
+        /// </summary>
+        public string RecentBlockhash { get; set; }
+
+        /// <summary>
+        /// Return the message version
+        /// </summary>
+        /// <returns></returns>
+        public virtual int Version()
+        {
+            return 0;
+        }
+
+        /// <summary>
+        /// Return the number of accounts in the tables lookups
+        /// </summary>
+        /// <returns></returns>
+        public int GetNumberAccountKeysFromLookups() 
+        {
+            int count = 0;
+            foreach(var lookup in AddressTableLookups)
+            {
+                count += lookup.ReadonlyIndexes.Length + lookup.WritableIndexes.Length;
+            }
+
+            return count;
+        }
+
+        public MessageAccountKeys GetAccountKey(AccountKeysFromLookups accountKeysFromLookups, AddressLookupTableAccount addressLookupTableAccount)
+        {
+            if (GetNumberAccountKeysFromLookups() != staticAccount.Count)
+        }        
+
+        /// <summary>
+        /// Check whether an account is writable.
+        /// </summary>
+        /// <param name="index">The index of the account in the account keys.</param>
+        /// <returns>true if the account is writable, false otherwise.</returns>
+        public bool IsAccountWritable(int index)
+        {
+            int numSignedAccounts = Header.RequiredSignatures;
+            int numStaticAccountKeys = AccountKeys.Count;
+            
+            if (index >= numStaticAccountKeys)
+            {
+                int lookupAccountKeysIndex = index - numStaticAccountKeys;
+                int numWritableLookupAccountKeys = this.AddressTableLookups.Select(p => p.WritableIndexes.Length).DefaultIfEmpty(0).Sum();
+                return lookupAccountKeysIndex < numWritableLookupAccountKeys;
+            }
+            else if (index >= this.Header.RequiredSignatures)
+            {
+                int unsignedAccountIndex = index - numSignedAccounts;
+                int numUnsignedAccounts = numStaticAccountKeys - numSignedAccounts;
+                int numWritableUnsignedAccounts = numUnsignedAccounts - this.Header.ReadOnlyUnsignedAccounts;
+                return unsignedAccountIndex < numWritableUnsignedAccounts;
+            }
+            else
+            {
+                int numWritableSignedAccounts = numSignedAccounts - this.Header.ReadOnlySignedAccounts;
+                return index < numWritableSignedAccounts;
+            }
+        }
+
+        /// <summary>
+        /// Check whether an account is a signer.
+        /// </summary>
+        /// <param name="index">The index of the account in the account keys.</param>
+        /// <returns>true if the account is an expected signer, false otherwise.</returns>
+        public bool IsAccountSigner(int index) => index < Header.RequiredSignatures;
+
+        /// <summary>
+        /// Serialize the message into the wire format.
+        /// </summary>
+        /// <returns>A byte array corresponding to the serialized message.</returns>
+        public byte[] Serialize()
+        {
+            byte[] accountAddressesLength = ShortVectorEncoding.EncodeLength(AccountKeys.Count);
+            byte[] instructionsLength = ShortVectorEncoding.EncodeLength(Instructions.Count);
+            byte[] addressTableLookupsLength = ShortVectorEncoding.EncodeLength(AddressTableLookups.Count);
+            int accountKeysBufferSize = AccountKeys.Count * 32;
+
+            MemoryStream accountKeysBuffer = new(accountKeysBufferSize);
+
+            foreach (PublicKey key in AccountKeys)
+            {
+                accountKeysBuffer.Write(key.KeyBytes);
+            }
+
+            int messageBufferSize = MessageHeader.Layout.HeaderLength + PublicKey.PublicKeyLength +
+                                    accountAddressesLength.Length + addressTableLookupsLength.Length
+                                    +instructionsLength.Length + Instructions.Count + accountKeysBufferSize;
+            MemoryStream buffer = new(messageBufferSize);
+            buffer.Write(Header.ToBytes());
+            buffer.Write(accountAddressesLength);
+            buffer.Write(accountKeysBuffer.ToArray());
+            buffer.Write(Encoders.Base58.DecodeData(RecentBlockhash));
+            buffer.Write(instructionsLength);
+
+            foreach (CompiledInstruction compiledInstruction in Instructions)
+            {
+                buffer.WriteByte(compiledInstruction.ProgramIdIndex);
+                buffer.Write(compiledInstruction.KeyIndicesCount);
+                buffer.Write(compiledInstruction.KeyIndices);
+                buffer.Write(compiledInstruction.DataLength);
+                buffer.Write(compiledInstruction.Data);
+            }
+
+            buffer.Write(addressTableLookupsLength);
+
+            foreach(var addressTableLookup in AddressTableLookups)
+            {
+                // buffer.Write
+            }
+
+
+            return buffer.ToArray();
+        }
+
+        /// <summary>
+        /// Deserialize a compiled message into a Message object.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the Message object.</param>
+        /// <returns>The Message object instance.</returns>
+        public static MessageV0 Deserialize(ReadOnlySpan<byte> data)
+        {
+            // Read message header
+            byte numRequiredSignatures = data[MessageHeader.Layout.RequiredSignaturesOffset];
+            byte numReadOnlySignedAccounts = data[MessageHeader.Layout.ReadOnlySignedAccountsOffset];
+            byte numReadOnlyUnsignedAccounts = data[MessageHeader.Layout.ReadOnlyUnsignedAccountsOffset];
+
+            // Read account keys
+            (int accountAddressLength, int accountAddressLengthEncodedLength) =
+                ShortVectorEncoding.DecodeLength(data.Slice(MessageHeader.Layout.HeaderLength,
+                    ShortVectorEncoding.SpanLength));
+            List<PublicKey> accountKeys = new(accountAddressLength);
+            for (int i = 0; i < accountAddressLength; i++)
+            {
+                ReadOnlySpan<byte> keyBytes = data.Slice(
+                    MessageHeader.Layout.HeaderLength + accountAddressLengthEncodedLength +
+                    i * PublicKey.PublicKeyLength,
+                    PublicKey.PublicKeyLength);
+                accountKeys.Add(new PublicKey(keyBytes));
+            }
+
+            // Read block hash
+            string blockHash =
+                Encoders.Base58.EncodeData(data.Slice(
+                    MessageHeader.Layout.HeaderLength + accountAddressLengthEncodedLength +
+                    accountAddressLength * PublicKey.PublicKeyLength,
+                    PublicKey.PublicKeyLength).ToArray());
+
+            // Read the number of instructions in the message
+            (int instructionsLength, int instructionsLengthEncodedLength) =
+                ShortVectorEncoding.DecodeLength(
+                    data.Slice(
+                        MessageHeader.Layout.HeaderLength + accountAddressLengthEncodedLength +
+                        (accountAddressLength * PublicKey.PublicKeyLength) + PublicKey.PublicKeyLength,
+                        ShortVectorEncoding.SpanLength));
+
+            List<CompiledInstruction> instructions = new(instructionsLength);
+            int instructionsOffset =
+                MessageHeader.Layout.HeaderLength + accountAddressLengthEncodedLength +
+                (accountAddressLength * PublicKey.PublicKeyLength) + PublicKey.PublicKeyLength +
+                instructionsLengthEncodedLength;
+            ReadOnlySpan<byte> instructionsData = data[instructionsOffset..];
+
+            // Read the instructions in the message
+            for (int i = 0; i < instructionsLength; i++)
+            {
+                (CompiledInstruction compiledInstruction, int instructionLength) =
+                    CompiledInstruction.Deserialize(instructionsData);
+                instructions.Add(compiledInstruction);
+                instructionsData = instructionsData[instructionLength..];
+            }
+
+            return new MessageV0
+            {
+                Header = new MessageHeader
+                {
+                    RequiredSignatures = numRequiredSignatures,
+                    ReadOnlySignedAccounts = numReadOnlySignedAccounts,
+                    ReadOnlyUnsignedAccounts = numReadOnlyUnsignedAccounts
+                },
+                RecentBlockhash = blockHash,
+                AccountKeys = accountKeys,
+                Instructions = instructions,
+            };
+        }
+
+        /// <summary>
+        /// Deserialize a compiled message encoded as base-64 into a Message object.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the Message object.</param>
+        /// <returns>The Transaction object.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the given string is null.</exception>
+        public static MessageV0 Deserialize(string data)
+        {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
+            byte[] decodedBytes;
+
+            try
+            {
+                decodedBytes = Convert.FromBase64String(data);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("could not decode message data from base64", ex);
+            }
+
+            return Deserialize(decodedBytes);
+        }
+    }
+
+    /// <summary>
+    /// Address table lookup for a versionned transaction
+    /// </summary>
+    public class MessageAddressTableLookup
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value></value>
+        public PublicKey AccountKey { get; set; }
+
+        /// <summary>
+        /// Indexes for readonly address
+        /// </summary>
+        /// <value></value>
+        public int[] ReadonlyIndexes { get; set; }
+
+        /// <summary>
+        /// Indexes for writable address
+        /// </summary>
+        /// <value></value>
+        public int[] WritableIndexes { get; set; }
+    }
+
+    /// <summary>
+    /// Represent an account key from a lookup
+    /// </summary>
+    public class AccountKeysFromLookups 
+    {
+        /// <summary>
+        /// Writables accounts
+        /// </summary>
+        /// <value></value>
+        public PublicKey[] Writables { get ; set; }
+
+        /// <summary>
+        /// Readonly accounts
+        /// </summary>
+        /// <value></value>
+        public PublicKey[] Readonly { get; set; }
+    }
+}

--- a/src/Solnet.Rpc/Models/Transaction.cs
+++ b/src/Solnet.Rpc/Models/Transaction.cs
@@ -405,4 +405,372 @@ namespace Solnet.Rpc.Models
             return Deserialize(decodedBytes);
         }
     }
+
+
+    /// <summary>
+    /// Represents a Transaction in Solana.
+    /// </summary>
+    public class TransactionV0
+    {
+        /// <summary>
+        /// The transaction's fee payer.
+        /// </summary>
+        public PublicKey FeePayer { get; set; }
+
+        /// <summary>
+        /// The list of <see cref="TransactionInstruction"/>s present in the transaction.
+        /// </summary>
+        public List<TransactionInstruction> Instructions { get; set; }
+
+        /// <summary>
+        /// The recent block hash for the transaction.
+        /// </summary>
+        public string RecentBlockHash { get; set; }
+
+        /// <summary>
+        /// The nonce information of the transaction.
+        /// <remarks>
+        /// When this is set, the <see cref="NonceInformation"/>'s Nonce is used as the <c>RecentBlockhash</c>.
+        /// </remarks>
+        /// </summary>
+        public NonceInformation NonceInformation { get; set; }
+
+        /// <summary>
+        /// The signatures for the transaction.
+        /// <remarks>
+        /// These are typically created by invoking the <c>Build(IList{Account} signers)</c> method of the <see cref="TransactionBuilder"/>,
+        /// but can be created by deserializing a Transaction and adding signatures manually.
+        /// </remarks>
+        /// </summary>
+        public List<SignaturePubKeyPair> Signatures { get; set; }
+
+        /// <summary>
+        /// Compile the transaction data.
+        /// </summary>
+        public byte[] CompileMessage()
+        {
+            MessageBuilder messageBuilder = new() { FeePayer = FeePayer };
+
+            if (RecentBlockHash != null) messageBuilder.RecentBlockHash = RecentBlockHash;
+            if (NonceInformation != null) messageBuilder.NonceInformation = NonceInformation;
+
+            foreach (TransactionInstruction instruction in Instructions)
+            {
+                messageBuilder.AddInstruction(instruction);
+            }
+
+            return messageBuilder.Build();
+        }
+
+        /// <summary>
+        /// Verifies the signatures a given serialized message.
+        /// </summary>
+        /// <returns>true if they are valid, false otherwise.</returns>
+        private bool VerifySignatures(byte[] serializedMessage) =>
+            Signatures.All(pair => pair.PublicKey.Verify(serializedMessage, pair.Signature));
+
+        /// <summary>
+        /// Verifies the signatures of a complete and signed transaction.
+        /// </summary>
+        /// <returns>true if they are valid, false otherwise.</returns>
+        public bool VerifySignatures() => VerifySignatures(CompileMessage());
+
+        /// <summary>
+        /// Sign the transaction with the specified signers. Multiple signatures may be applied to a transaction.
+        /// The first signature is considered primary and is used to identify and confirm transaction.
+        /// <remarks>
+        /// <para>
+        /// If the transaction <c>FeePayer</c> is not set, the first signer will be used as the transaction fee payer account.
+        /// </para>
+        /// <para>
+        /// Transaction fields SHOULD NOT be modified after the first call to <c>Sign</c> or an externally created signature
+        /// has been added to the transaction object, doing so will invalidate the signature and cause the transaction to be
+        /// rejected by the cluster.
+        /// </para>
+        /// <para>
+        /// The transaction must have been assigned a valid <c>RecentBlockHash</c> or <c>NonceInformation</c> before invoking this method.
+        /// </para>
+        /// </remarks>
+        /// </summary>
+        /// <param name="signers">The signer accounts.</param>
+        public bool Sign(IList<Account> signers)
+        {
+            Signatures ??= new List<SignaturePubKeyPair>();
+            IEnumerable<Account> uniqueSigners = DeduplicateSigners(signers);
+            byte[] serializedMessage = CompileMessage();
+
+            foreach (Account account in uniqueSigners)
+            {
+                byte[] signatureBytes = account.Sign(serializedMessage);
+                Signatures.Add(new SignaturePubKeyPair { PublicKey = account.PublicKey, Signature = signatureBytes });
+            }
+
+            return VerifySignatures();
+        }
+
+        /// <summary>
+        /// Sign the transaction with the specified signer. Multiple signatures may be applied to a transaction.
+        /// The first signature is considered primary and is used to identify and confirm transaction.
+        /// <remarks>
+        /// <para>
+        /// If the transaction <c>FeePayer</c> is not set, the first signer will be used as the transaction fee payer account.
+        /// </para>
+        /// <para>
+        /// Transaction fields SHOULD NOT be modified after the first call to <c>Sign</c> or an externally created signature
+        /// has been added to the transaction object, doing so will invalidate the signature and cause the transaction to be
+        /// rejected by the cluster.
+        /// </para>
+        /// <para>
+        /// The transaction must have been assigned a valid <c>RecentBlockHash</c> or <c>NonceInformation</c> before invoking this method.
+        /// </para>
+        /// </remarks>
+        /// </summary>
+        /// <param name="signer">The signer account.</param>
+        public bool Sign(Account signer) => Sign(new List<Account> { signer });
+
+        /// <summary>
+        /// Partially sign a transaction with the specified accounts.
+        /// All accounts must correspond to either the fee payer or a signer account in the transaction instructions.
+        /// </summary>
+        /// <param name="signers">The signer accounts.</param>
+        public void PartialSign(IList<Account> signers)
+        {
+            Signatures ??= new List<SignaturePubKeyPair>();
+            IEnumerable<Account> uniqueSigners = DeduplicateSigners(signers);
+            byte[] serializedMessage = CompileMessage();
+
+            foreach (Account account in uniqueSigners)
+            {
+                byte[] signatureBytes = account.Sign(serializedMessage);
+                Signatures.Add(new SignaturePubKeyPair { PublicKey = account.PublicKey, Signature = signatureBytes });
+            }
+        }
+
+        /// <summary>
+        /// Deduplicate the list of given signers.
+        /// </summary>
+        /// <param name="signers">The signer accounts.</param>
+        /// <returns>The signer accounts with removed duplicates</returns>
+        private static IEnumerable<Account> DeduplicateSigners(IEnumerable<Account> signers)
+        {
+            List<Account> uniqueSigners = new();
+            HashSet<Account> seen = new();
+
+            foreach (Account account in signers)
+            {
+                if (seen.Contains(account)) continue;
+
+                seen.Add(account);
+                uniqueSigners.Add(account);
+            }
+
+            return uniqueSigners;
+        }
+
+        /// <summary>
+        /// Partially sign a transaction with the specified account.
+        /// The account must correspond to either the fee payer or a signer account in the transaction instructions.
+        /// </summary>
+        /// <param name="signer">The signer account.</param>
+        public void PartialSign(Account signer) => PartialSign(new List<Account> { signer });
+
+        /// <summary>
+        /// Signs the transaction's message with the passed signer and add it to the transaction, serializing it.
+        /// </summary>
+        /// <param name="signer">The signer.</param>
+        /// <returns>The serialized transaction.</returns>
+        public byte[] Build(Account signer)
+        {
+            return Build(new List<Account> { signer });
+        }
+
+        /// <summary>
+        /// Signs the transaction's message with the passed list of signers and adds them to the transaction, serializing it.
+        /// </summary>
+        /// <param name="signers">The list of signers.</param>
+        /// <returns>The serialized transaction.</returns>
+        public byte[] Build(IList<Account> signers)
+        {
+            Sign(signers);
+
+            return Serialize();
+        }
+
+        /// <summary>
+        /// Adds an externally created signature to the transaction.
+        /// The public key must correspond to either the fee payer or a signer account in the transaction instructions.
+        /// </summary>
+        /// <param name="publicKey">The public key of the account that signed the transaction.</param>
+        /// <param name="signature">The transaction signature.</param>
+        public void AddSignature(PublicKey publicKey, byte[] signature)
+        {
+            Signatures ??= new List<SignaturePubKeyPair>();
+            Signatures.Add(new SignaturePubKeyPair { PublicKey = publicKey, Signature = signature });
+        }
+
+        /// <summary>
+        /// Adds one or more instructions to the transaction.
+        /// </summary>
+        /// <param name="instructions">The instructions to add.</param>
+        /// <returns>The transaction instance.</returns>
+        public Transaction Add(IEnumerable<TransactionInstruction> instructions)
+        {
+            Instructions ??= new List<TransactionInstruction>();
+            Instructions.AddRange(instructions);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an instruction to the transaction.
+        /// </summary>
+        /// <param name="instruction">The instruction to add.</param>
+        /// <returns>The transaction instance.</returns>
+        public Transaction Add(TransactionInstruction instruction) =>
+            Add(new List<TransactionInstruction> { instruction });
+
+        /// <summary>
+        /// Serializes the transaction into wire format.
+        /// </summary>
+        /// <returns>The transaction encoded in wire format.</returns>
+        public byte[] Serialize()
+        {
+            byte[] signaturesLength = ShortVectorEncoding.EncodeLength(Signatures.Count);
+            byte[] serializedMessage = CompileMessage();
+            MemoryStream buffer = new(signaturesLength.Length + Signatures.Count * TransactionBuilder.SignatureLength +
+                                      serializedMessage.Length);
+
+            buffer.Write(signaturesLength);
+            foreach (SignaturePubKeyPair signaturePair in Signatures)
+            {
+                buffer.Write(signaturePair.Signature);
+            }
+
+            buffer.Write(serializedMessage);
+            return buffer.ToArray();
+        }
+
+        /// <summary>
+        /// Populate the Transaction from the given message and signatures.
+        /// </summary>
+        /// <param name="message">The <see cref="Message"/> object.</param>
+        /// <param name="signatures">The list of signatures.</param>
+        /// <returns>The Transaction object.</returns>
+        public static Transaction Populate(Message message, IList<byte[]> signatures = null)
+        {
+            Transaction tx = new()
+            {
+                RecentBlockHash = message.RecentBlockhash,
+                Signatures = new List<SignaturePubKeyPair>(),
+                Instructions = new List<TransactionInstruction>()
+            };
+
+            if (message.Header.RequiredSignatures > 0)
+            {
+                tx.FeePayer = message.AccountKeys[0];
+            }
+
+            if (signatures != null)
+            {
+                for (int i = 0; i < signatures.Count; i++)
+                {
+                    tx.Signatures.Add(new SignaturePubKeyPair
+                    {
+                        PublicKey = message.AccountKeys[i],
+                        Signature = signatures[i]
+                    });
+                }
+            }
+
+            for (int i = 0; i < message.Instructions.Count; i++)
+            {
+                CompiledInstruction compiledInstruction = message.Instructions[i];
+                (int accountLength, _) = ShortVectorEncoding.DecodeLength(compiledInstruction.KeyIndicesCount);
+
+                List<AccountMeta> accounts = new(accountLength);
+                for (int j = 0; j < accountLength; j++)
+                {
+                    int k = compiledInstruction.KeyIndices[j];
+                    accounts.Add(new AccountMeta(message.AccountKeys[k], message.IsAccountWritable(k),
+                        tx.Signatures.Any(pair => pair.PublicKey.Key == message.AccountKeys[k].Key) || message.IsAccountSigner(k)));
+                }
+
+                TransactionInstruction instruction = new()
+                {
+                    Keys = accounts,
+                    ProgramId = message.AccountKeys[compiledInstruction.ProgramIdIndex],
+                    Data = compiledInstruction.Data
+                };
+                if (i == 0 && accounts.Any(a => a.PublicKey == "SysvarRecentB1ockHashes11111111111111111111"))
+                {
+                    tx.NonceInformation = new NonceInformation { Instruction = instruction, Nonce = tx.RecentBlockHash };
+                    continue;
+                }
+                tx.Instructions.Add(instruction);
+            }
+
+            return tx;
+        }
+
+        /// <summary>
+        /// Populate the Transaction from the given compiled message and signatures.
+        /// </summary>
+        /// <param name="message">The compiled message, as base-64 encoded string.</param>
+        /// <param name="signatures">The list of signatures.</param>
+        /// <returns>The Transaction object.</returns>
+        public static Transaction Populate(string message, IList<byte[]> signatures = null)
+            => Populate(Message.Deserialize(message), signatures);
+
+        /// <summary>
+        /// Deserialize a wire format transaction into a Transaction object.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the Transaction object.</param>
+        /// <returns>The Transaction object.</returns>
+        public static Transaction Deserialize(ReadOnlySpan<byte> data)
+        {
+            // Read number of signatures
+            (int signaturesLength, int encodedLength) =
+                ShortVectorEncoding.DecodeLength(data[..ShortVectorEncoding.SpanLength]);
+            List<byte[]> signatures = new(signaturesLength);
+
+            for (int i = 0; i < signaturesLength; i++)
+            {
+                ReadOnlySpan<byte> signature =
+                    data.Slice(encodedLength + (i * TransactionBuilder.SignatureLength),
+                        TransactionBuilder.SignatureLength);
+                signatures.Add(signature.ToArray());
+            }
+
+            return Populate(
+                Message.Deserialize(data[
+                    (encodedLength + (signaturesLength * TransactionBuilder.SignatureLength))..]),
+                signatures);
+        }
+
+        /// <summary>
+        /// Deserialize a transaction encoded as base-64 into a Transaction object.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the Transaction object.</param>
+        /// <returns>The Transaction object.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the given string is null.</exception>
+        public static Transaction Deserialize(string data)
+        {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
+            byte[] decodedBytes;
+
+            try
+            {
+                decodedBytes = Convert.FromBase64String(data);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("could not decode transaction data from base64", ex);
+            }
+
+            return Deserialize(decodedBytes);
+        }
+    }
+
+
 }

--- a/src/Solnet.Rpc/SolanaRpcClient.cs
+++ b/src/Solnet.Rpc/SolanaRpcClient.cs
@@ -223,6 +223,7 @@ namespace Solnet.Rpc
                     KeyValue.Create("encoding", "json"),
                     HandleTransactionDetails(transactionDetails),
                     KeyValue.Create("rewards", blockRewards ? blockRewards : null),
+                    KeyValue.Create("maxSupportedTransactionVersion", 0),
                     HandleCommitment(commitment))));
         }
 
@@ -429,7 +430,7 @@ namespace Solnet.Rpc
         {
             return await SendRequestAsync<TransactionMetaSlotInfo>("getTransaction",
                 Parameters.Create(signature,
-                    ConfigObject.Create(KeyValue.Create("encoding", "json"), HandleCommitment(commitment))));
+                    ConfigObject.Create(KeyValue.Create("encoding", "json"), HandleCommitment(commitment), KeyValue.Create("maxSupportedTransactionVersion", 0))));
         }
 
         /// <inheritdoc cref="IRpcClient.GetConfirmedTransactionAsync(string, Commitment)"/>

--- a/src/Solnet.Rpc/SolanaRpcClient.cs
+++ b/src/Solnet.Rpc/SolanaRpcClient.cs
@@ -209,7 +209,7 @@ namespace Solnet.Rpc
 
         /// <inheritdoc cref="IRpcClient.GetBlockAsync"/>
         public async Task<RequestResult<BlockInfo>> GetBlockAsync(ulong slot,
-            Commitment commitment = Commitment.Finalized,
+            Commitment commitment = Commitment.Finalized, int maxSupportedTransactionVersion = 0,
             TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full,
             bool blockRewards = false)
         {
@@ -223,15 +223,15 @@ namespace Solnet.Rpc
                     KeyValue.Create("encoding", "json"),
                     HandleTransactionDetails(transactionDetails),
                     KeyValue.Create("rewards", blockRewards ? blockRewards : null),
-                    KeyValue.Create("maxSupportedTransactionVersion", 0),
+                    KeyValue.Create("maxSupportedTransactionVersion", maxSupportedTransactionVersion),
                     HandleCommitment(commitment))));
         }
 
         /// <inheritdoc cref="IRpcClient.GetBlock"/>
         public RequestResult<BlockInfo> GetBlock(ulong slot, Commitment commitment = Commitment.Finalized,
-            TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full,
+            int maxSupportedTransactionVersion = 0, TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full,
             bool blockRewards = false)
-            => GetBlockAsync(slot, commitment, transactionDetails, blockRewards).Result;
+            => GetBlockAsync(slot, commitment, maxSupportedTransactionVersion, transactionDetails, blockRewards).Result;
 
 
         /// <inheritdoc cref="IRpcClient.GetBlocksAsync"/>
@@ -250,7 +250,7 @@ namespace Solnet.Rpc
 
         /// <inheritdoc cref="IRpcClient.GetConfirmedBlockAsync"/>
         public async Task<RequestResult<BlockInfo>> GetConfirmedBlockAsync(ulong slot,
-            Commitment commitment = Commitment.Finalized,
+            Commitment commitment = Commitment.Finalized, int maxSupportedTransactionVersion = 0,
             TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full,
             bool blockRewards = false)
         {
@@ -264,14 +264,15 @@ namespace Solnet.Rpc
                     KeyValue.Create("encoding", "json"),
                     HandleTransactionDetails(transactionDetails),
                     KeyValue.Create("rewards", blockRewards ? blockRewards : null),
-                    HandleCommitment(commitment))));
+                    HandleCommitment(commitment),
+                    KeyValue.Create("maxSupportedTransactionVersion" ,maxSupportedTransactionVersion))));
         }
 
         /// <inheritdoc cref="IRpcClient.GetConfirmedBlock"/>
         public RequestResult<BlockInfo> GetConfirmedBlock(ulong slot, Commitment commitment = Commitment.Finalized,
-            TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full,
+            int maxSupportedTransactionVersion = 0, TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full,
             bool blockRewards = false)
-            => GetConfirmedBlockAsync(slot, commitment, transactionDetails, blockRewards).Result;
+            => GetConfirmedBlockAsync(slot, commitment, maxSupportedTransactionVersion, transactionDetails, blockRewards).Result;
 
 
         /// <inheritdoc cref="IRpcClient.GetBlocks"/>
@@ -426,31 +427,35 @@ namespace Solnet.Rpc
 
         /// <inheritdoc cref="IRpcClient.GetTransactionAsync"/>
         public async Task<RequestResult<TransactionMetaSlotInfo>> GetTransactionAsync(string signature,
-            Commitment commitment = Commitment.Finalized)
+            Commitment commitment = Commitment.Finalized, int maxSupportedTransactionVersion = 0)
         {
             return await SendRequestAsync<TransactionMetaSlotInfo>("getTransaction",
                 Parameters.Create(signature,
-                    ConfigObject.Create(KeyValue.Create("encoding", "json"), HandleCommitment(commitment), KeyValue.Create("maxSupportedTransactionVersion", 0))));
+                    ConfigObject.Create(KeyValue.Create("encoding", "json"), 
+                                        HandleCommitment(commitment), 
+                                        KeyValue.Create("maxSupportedTransactionVersion", maxSupportedTransactionVersion))));
         }
 
-        /// <inheritdoc cref="IRpcClient.GetConfirmedTransactionAsync(string, Commitment)"/>
+        /// <inheritdoc cref="IRpcClient.GetConfirmedTransactionAsync(string, Commitment, int)"/>
         public async Task<RequestResult<TransactionMetaSlotInfo>> GetConfirmedTransactionAsync(string signature,
-            Commitment commitment = Commitment.Finalized)
+            Commitment commitment = Commitment.Finalized, int maxSupportedTransactionVersion = 0)
         {
             return await SendRequestAsync<TransactionMetaSlotInfo>("getConfirmedTransaction",
                 Parameters.Create(signature,
-                    ConfigObject.Create(KeyValue.Create("encoding", "json"), HandleCommitment(commitment))));
+                    ConfigObject.Create(KeyValue.Create("encoding", "json"), 
+                                        HandleCommitment(commitment),
+                                        KeyValue.Create("maxSupportedTransactionVersion", maxSupportedTransactionVersion))));
         }
 
         /// <inheritdoc cref="IRpcClient.GetTransaction"/>
         public RequestResult<TransactionMetaSlotInfo> GetTransaction(string signature,
-            Commitment commitment = Commitment.Finalized)
-            => GetTransactionAsync(signature, commitment).Result;
+            Commitment commitment = Commitment.Finalized, int maxSupportedTransactionVersion = 0)
+            => GetTransactionAsync(signature, commitment, maxSupportedTransactionVersion).Result;
 
-        /// <inheritdoc cref="IRpcClient.GetConfirmedTransaction(string, Commitment)"/>
+        /// <inheritdoc cref="IRpcClient.GetConfirmedTransaction(string, Commitment, int)"/>
         public RequestResult<TransactionMetaSlotInfo> GetConfirmedTransaction(string signature,
-            Commitment commitment = Commitment.Finalized) =>
-            GetConfirmedTransactionAsync(signature, commitment).Result;
+            Commitment commitment = Commitment.Finalized, int maxSupportedTransactionVersion = 0) =>
+            GetConfirmedTransactionAsync(signature, commitment, maxSupportedTransactionVersion).Result;
 
         /// <inheritdoc cref="IRpcClient.GetBlockHeightAsync"/>
         public async Task<RequestResult<ulong>> GetBlockHeightAsync(Commitment commitment = Commitment.Finalized)

--- a/test/Solnet.Rpc.Test/Resources/Http/Blocks/GetBlockConfirmedRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Blocks/GetBlockConfirmedRequest.json
@@ -1,1 +1,1 @@
-{"method":"getBlock","params":[79662905,{"encoding":"json","commitment":"confirmed"}],"jsonrpc":"2.0","id":0}
+{"method":"getBlock","params":[79662905,{"encoding":"json","maxSupportedTransactionVersion":0,"commitment":"confirmed"}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/Blocks/GetBlockRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Blocks/GetBlockRequest.json
@@ -1,1 +1,1 @@
-{"method":"getBlock","params":[79662905,{"encoding":"json"}],"jsonrpc":"2.0","id":0}
+{"method":"getBlock","params":[79662905,{"encoding":"json","maxSupportedTransactionVersion":0}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetTransactionProcessedRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetTransactionProcessedRequest.json
@@ -1,1 +1,1 @@
-{"method":"getTransaction","params":["5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1",{"encoding":"json","commitment":"processed"}],"jsonrpc":"2.0","id":0}
+{"method":"getTransaction","params":["5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1",{"encoding":"json","commitment":"processed","maxSupportedTransactionVersion":0}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetTransactionRequest.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetTransactionRequest.json
@@ -1,1 +1,1 @@
-{"method":"getTransaction","params":["5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1",{"encoding":"json"}],"jsonrpc":"2.0","id":0}
+{"method":"getTransaction","params":["5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1",{"encoding":"json","maxSupportedTransactionVersion":0}],"jsonrpc":"2.0","id":0}

--- a/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetTransactionRequest2.json
+++ b/test/Solnet.Rpc.Test/Resources/Http/Transaction/GetTransactionRequest2.json
@@ -1,1 +1,1 @@
-{"method":"getTransaction","params":["3Q9mu4ePvtbtQzY1kpGmaViJKyBev6hgUppyXDF9hKgWHHnecwGLE2pSoFvNUF3h7acKyFwWd65bkwr9A1jN2CdT",{"encoding":"json"}],"jsonrpc":"2.0","id":0}
+{"method":"getTransaction","params":["3Q9mu4ePvtbtQzY1kpGmaViJKyBev6hgUppyXDF9hKgWHHnecwGLE2pSoFvNUF3h7acKyFwWd65bkwr9A1jN2CdT",{"encoding":"json","maxSupportedTransactionVersion":0}],"jsonrpc":"2.0","id":0}


### PR DESCRIPTION
This PR aim to fix the issue #426  

Solana added versionned transaction since EPOCH 358.

Current version of solnet only support `getTransaction` and `getBlock` on LEGACY version.
To be able to call getTransaction or getBlock on versionned transaction, the optionnal parameter `maxSupportedTransactionVersion` need to be set to `0`.

