### PR TITLE
use asynchronous with RateLimiter

### DIFF
--- a/src/Solnet.Rpc/Core/Http/JsonRpcClient.cs
+++ b/src/Solnet.Rpc/Core/Http/JsonRpcClient.cs
@@ -78,8 +78,8 @@ namespace Solnet.Rpc.Core.Http
             try
             {
                 // pre-flight check with rate limiter if set
-                _rateLimiter?.Fire(); 
-                
+                await (_rateLimiter?.WaitFireAsync() ?? Task.CompletedTask);
+
                 // logging
                 _logger?.LogInformation(new EventId(req.Id, req.Method), $"Sending request: {requestJson}");
 
@@ -189,8 +189,8 @@ namespace Solnet.Rpc.Core.Http
             try
             {
                 // pre-flight check with rate limiter if set
-                _rateLimiter?.Fire(); 
-                
+                await (_rateLimiter?.WaitFireAsync() ?? Task.CompletedTask);
+
                 _logger?.LogInformation(new EventId(id_for_log, $"[batch of {reqs.Count}]"), $"Sending request: {requestsJson}");
 
                 // create byte buffer to avoid charset=utf-8 in content-type header

--- a/src/Solnet.Rpc/Utilities/IRateLimiter.cs
+++ b/src/Solnet.Rpc/Utilities/IRateLimiter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Solnet.Rpc.Utilities
@@ -15,7 +16,15 @@ namespace Solnet.Rpc.Utilities
         /// <summary>
         /// Fire or block until we can fire.
         /// </summary>
+        [Obsolete]
         void Fire();
+
+        /// <summary>
+        /// Fire or block until we can fire.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task WaitFireAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Would a fire method succeed?
@@ -23,5 +32,5 @@ namespace Solnet.Rpc.Utilities
         /// <returns></returns>
         bool CanFire();
 
-     }
+    }
 }

--- a/src/Solnet.Rpc/Utilities/RateLimiter.cs
+++ b/src/Solnet.Rpc/Utilities/RateLimiter.cs
@@ -52,6 +52,7 @@ namespace Solnet.Rpc.Utilities
         /// <summary>
         /// Pre-fire check - this will block if fire rates exceed defined limits until valid.
         /// </summary>
+        [Obsolete]
         public void Fire()
         {
 
@@ -65,6 +66,24 @@ namespace Solnet.Rpc.Utilities
             if (_duration_ms > 0)
                 _hit_list.Enqueue(DateTime.UtcNow);
 
+        }
+
+        /// <summary>
+        /// Pre-fire check - this will block if fire rates exceed defined limits until valid.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task WaitFireAsync(CancellationToken cancellationToken = default)
+        {
+            var checkTime = DateTime.UtcNow;
+            var resumeTime = NextFireAllowed(checkTime);
+            var snoozeMs = resumeTime.Subtract(checkTime).TotalMilliseconds;
+            while (DateTime.UtcNow <= resumeTime)
+                await Task.Delay(50, cancellationToken);
+
+            // record this trigger
+            if (_duration_ms > 0)
+                _hit_list.Enqueue(DateTime.UtcNow);
         }
 
         /// <summary>

--- a/test/Solnet.Rpc.Test/SolanaRpcRateLimitingTests.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcRateLimitingTests.cs
@@ -69,12 +69,76 @@ namespace Solnet.Rpc.Test
             Console.WriteLine(limit);
 
             // observe why this may break the build
-            var finalTimeCheck= DateTime.UtcNow;
+            var finalTimeCheck = DateTime.UtcNow;
             Console.WriteLine($" ExecTime diff {finalTimeCheck.Subtract(timeCheck).TotalMilliseconds}ms");
             Console.WriteLine($"TimeCheck diff {finalTimeCheck.Subtract(twoSecondsLater).TotalMilliseconds}ms");
-            Assert.IsTrue(finalTimeCheck.Subtract(timeCheck).TotalMilliseconds>2000, $"ExecTime diff {finalTimeCheck.Subtract(timeCheck).TotalMilliseconds}ms");
+            Assert.IsTrue(finalTimeCheck.Subtract(timeCheck).TotalMilliseconds > 2000, $"ExecTime diff {finalTimeCheck.Subtract(timeCheck).TotalMilliseconds}ms");
         }
 
+
+        [TestMethod]
+        public async Task TestMaxSpeed_NoLimits_Async()
+        {
+            // allow unlimited fires instantly
+            var limit = RateLimiter.Create();
+            Assert.IsTrue(limit.CanFire());
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+        }
+
+        [TestMethod]
+        public async Task TestMaxSpeed_WithinLimits_Async()
+        {
+            // allow unlimited fires instantly
+            var limit = RateLimiter.Create().AllowHits(100).PerSeconds(10);
+            Assert.IsTrue(limit.CanFire());
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+        }
+
+        [TestMethod]
+        public async Task TestTwoHitsPerSecond_Async()
+        {
+            // allow 2 hits per second
+            var timeCheck = DateTime.UtcNow;
+            var limit = RateLimiter.Create().AllowHits(2).PerSeconds(1);
+            var twoSecondsLater = timeCheck.AddSeconds(2);
+            Console.WriteLine(limit);
+            Assert.IsTrue(limit.CanFire());
+            Console.WriteLine(limit);
+            await limit.WaitFireAsync();
+            Console.WriteLine(limit);
+            await limit.WaitFireAsync();
+            Console.WriteLine(limit);
+            await limit.WaitFireAsync();
+            Console.WriteLine(limit);
+            await limit.WaitFireAsync();
+            Console.WriteLine(limit);
+            await limit.WaitFireAsync();
+            Console.WriteLine(limit);
+            await limit.WaitFireAsync();
+            Console.WriteLine(limit);
+            await limit.WaitFireAsync();
+            Console.WriteLine(limit);
+
+            // observe why this may break the build
+            var finalTimeCheck = DateTime.UtcNow;
+            Console.WriteLine($" ExecTime diff {finalTimeCheck.Subtract(timeCheck).TotalMilliseconds}ms");
+            Console.WriteLine($"TimeCheck diff {finalTimeCheck.Subtract(twoSecondsLater).TotalMilliseconds}ms");
+            Assert.IsTrue(finalTimeCheck.Subtract(timeCheck).TotalMilliseconds > 2000, $"ExecTime diff {finalTimeCheck.Subtract(timeCheck).TotalMilliseconds}ms");
+        }
     }
 
 }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Refactor| No | [Link](https://github.com/bmresearch/Solnet/issues/486) |

## Problem

Thread.Sleep is terrible for Task


## Solution

Change it to asynchronous with Task.Delay


## Before & After Screenshots

**BEFORE**:
![image](https://github.com/user-attachments/assets/9598e910-c589-4a97-9cc9-c3161a5677f1)
![image](https://github.com/user-attachments/assets/7e48e2c3-d247-4906-a06c-c000785abd55)
![image](https://github.com/user-attachments/assets/b96f1d64-4e69-418a-9bdc-1c47fe41b9bb)

**AFTER**:
![image](https://github.com/user-attachments/assets/82a3f34c-5984-4a98-a14c-cea7fc3fb8b8)
![image](https://github.com/user-attachments/assets/25f2f291-90f3-401c-b199-daedcba50d94)
![image](https://github.com/user-attachments/assets/b0aaa9f9-72b7-4cb0-9a96-ea53a6ea5024)

