### PR TITLE
Fix rate limiter tests

### DIFF
--- a/test/Solnet.Rpc.Test/SolanaRpcRateLimitingTests.cs
+++ b/test/Solnet.Rpc.Test/SolanaRpcRateLimitingTests.cs
@@ -12,39 +12,39 @@ namespace Solnet.Rpc.Test
     public class SolanaRpcRateLimitingTests
     {
         [TestMethod]
-        public void TestMaxSpeed_NoLimits()
+        public async Task TestMaxSpeed_NoLimits()
         {
             // allow unlimited fires instantly
             var limit = RateLimiter.Create();
             Assert.IsTrue(limit.CanFire());
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
         }
 
         [TestMethod]
-        public void TestMaxSpeed_WithinLimits()
+        public async Task TestMaxSpeed_WithinLimits()
         {
             // allow unlimited fires instantly
             var limit = RateLimiter.Create().AllowHits(100).PerSeconds(10);
             Assert.IsTrue(limit.CanFire());
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
-            limit.WaitFireAsync().Wait();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
+            await limit.WaitFireAsync();
         }
 
         [TestMethod]
-        public void TestTwoHitsPerSecond()
+        public async Task TestTwoHitsPerSecond()
         {
             // allow 2 hits per second
             var timeCheck = DateTime.UtcNow;
@@ -53,19 +53,19 @@ namespace Solnet.Rpc.Test
             Console.WriteLine(limit);
             Assert.IsTrue(limit.CanFire());
             Console.WriteLine(limit);
-            limit.WaitFireAsync().Wait();
+            await limit.WaitFireAsync();
             Console.WriteLine(limit);
-            limit.WaitFireAsync().Wait();
+            await limit.WaitFireAsync();
             Console.WriteLine(limit);
-            limit.WaitFireAsync().Wait();
+            await limit.WaitFireAsync();
             Console.WriteLine(limit);
-            limit.WaitFireAsync().Wait();
+            await limit.WaitFireAsync();
             Console.WriteLine(limit);
-            limit.WaitFireAsync().Wait();
+            await limit.WaitFireAsync();
             Console.WriteLine(limit);
-            limit.WaitFireAsync().Wait();
+            await limit.WaitFireAsync();
             Console.WriteLine(limit);
-            limit.WaitFireAsync().Wait();
+            await limit.WaitFireAsync();
             Console.WriteLine(limit);
 
             // observe why this may break the build
@@ -74,7 +74,6 @@ namespace Solnet.Rpc.Test
             Console.WriteLine($"TimeCheck diff {finalTimeCheck.Subtract(twoSecondsLater).TotalMilliseconds}ms");
             Assert.IsTrue(finalTimeCheck.Subtract(timeCheck).TotalMilliseconds > 2000, $"ExecTime diff {finalTimeCheck.Subtract(timeCheck).TotalMilliseconds}ms");
         }
-
 
         [TestMethod]
         public async Task TestMaxSpeed_NoLimits_Async()


### PR DESCRIPTION

## Problem

I identified several tests that were implementing the obsolete `.Fire()` method


## Solution

I switched affected tests to the `.WaitFireAsync()`


## Before & After Screenshots

_Insert screenshots of example code output_

**BEFORE**:
![image](https://github.com/user-attachments/assets/92bfb092-1ee6-4a22-84d8-ff47f67ed8b4)


**AFTER**:
![image](https://github.com/user-attachments/assets/0b539d0e-4071-4dc0-8d1c-435aa9102256)


## Other changes (e.g. bug fixes, small refactors)


## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details
